### PR TITLE
Fix #173: Fix github icon taking up too much vert space on mobile

### DIFF
--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -325,12 +325,12 @@ exports[`Storyshots Legend Legend Story 1`] = `
 exports[`Storyshots Maps Pump HoverTip Hover Object Story 1`] = `
 <div>
   <div
-    className="sc-pciEQ ciJEbL is-size-7"
+    className="sc-pjHjD jcrFml is-size-7"
     height={0}
     width={0}
   >
     <span
-      className="sc-oTNDV zfOYy"
+      className="sc-pciEQ jnZLfv"
     >
       <b>
         Status:
@@ -685,10 +685,10 @@ exports[`Storyshots Overlay Legend Story 1`] = `
 
 exports[`Storyshots Sidebar About 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -710,7 +710,7 @@ exports[`Storyshots Sidebar About 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -721,12 +721,12 @@ exports[`Storyshots Sidebar About 1`] = `
       className="sc-AxgMl gOOTwl"
     >
       <span
-        className="sc-fzoPby sc-fzooss WWGlw"
+        className="sc-fzoPby sc-fzqyvX hEnIIm"
       >
         Über das Projekt
       </span>
       <span
-        className="sc-fzpans sc-fzqyvX iicrtY"
+        className="sc-fzpans sc-fzqKVi gKkhAL"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Die Folgen des Klimawandels, insbesondere die trockenen und heißen Sommer, belasten das Berliner Ökosystem. Unsere Stadtbäume vertrocknen und tragen langfristige Schäden davon: In den letzten Jahren mussten immer mehr Bäume gefällt werden und ihre Lebensdauer sinkt. Inzwischen wird die Bevölkerung regelmäßig zur Unterstützung aufgerufen, allerdings weitgehend unkoordiniert. Dies möchten wir ändern und mit diesem Projekt eine koordinierte Bürger*innenbeteiligung bei der Bewässerung städtischen Grüns ermöglichen.",
@@ -738,12 +738,12 @@ exports[`Storyshots Sidebar About 1`] = `
       className="sc-AxgMl gOOTwl"
     >
       <span
-        className="sc-fzoPby sc-fzooss WWGlw"
+        className="sc-fzoPby sc-fzqyvX hEnIIm"
       >
         Nützliche Links
       </span>
       <span
-        className="sc-fzpans sc-fzqyvX iicrtY"
+        className="sc-fzpans sc-fzqKVi gKkhAL"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<ul><li><a target=\\"blank\\" href=\\"https://www.lieblingsbaum-initiative.de/\\">Initiative Lieblingsbaum</a></li><li><a target=\\"blank\\" href=\\"https://www.bund-berlin.de/mitmachen/aktion-baeume-giessen/\\">BUND - Aktion Bäume gießen</a></li><li><a target=\\"blank\\" href=\\"https://www.baumpflegeportal.de/baumpflege/trockenheit-duerre-wann-baeume-giessen/\\">Baumpflegeportal - Gießen bei Trockenheit</a></li><li><a target=\\"blank\\" href=\\"https://www.berlin.de/senuvk/umwelt/stadtgruen/stadtbaeume/kampagne/start.shtml\\">Stadtbaumkampagne Berlin</a></li><li><a target=\\"blank\\" href=\\"https://www.berlin.de/pflanzenschutzamt/stadtgruen/beratung/bewaesserungsempfehlung-fuer-stadtbaeume/\\">Projekt Bodenfeuchte Berlin</a></li><li><a target=\\"blank\\" href=\\"https://www.bmi.bund.de/SharedDocs/downloads/DE/publikationen/themen/bauen/wohnen/weissbuch-stadtgruen.html\\">Grünbuch Stadtgrün</a></li><li><a target=\\"blank\\" href=\\"https://www.hcu-hamburg.de/fileadmin/documents/REAP/files/Bildungsmaterial_Stadtbaeume_im_Klimawandel_2017.pdf\\">Stadtbäume - Bedeutung und Herausforderungen in Zeiten des Klimawandels</a></li><li><a target=\\"blank\\" href=\\"https://www.bund-naturschutz.de/natur-und-landschaft/stadt-als-lebensraum/stadtbaeume/funktionen-von-stadtbaeumen.html\\">BUND - Funktionen von Stadtbäumen</a></li></ul>",
@@ -755,12 +755,12 @@ exports[`Storyshots Sidebar About 1`] = `
       className="sc-AxgMl gOOTwl"
     >
       <span
-        className="sc-fzoPby sc-fzooss WWGlw"
+        className="sc-fzoPby sc-fzqyvX hEnIIm"
       >
         Über uns
       </span>
       <span
-        className="sc-fzpans sc-fzqyvX iicrtY"
+        className="sc-fzpans sc-fzqKVi gKkhAL"
         dangerouslySetInnerHTML={
           Object {
             "__html": "“Gieß den Kiez” ist ein Projekt des <a target=\\"blank\\" href=\\"https://www.citylab-berlin.org/\\">CityLAB Berlin</a>. Das CityLAB ist ein öffentliches Innovationslabor für die Stadt der Zukunft im ehemaligen Flughafen Berlin-Tempelhof. Gemeinsam mit einem großen Netzwerk aus Verwaltung, Zivilgesellschaft, Wissenschaft und Start-ups arbeiten wir an neuen Ideen für ein lebenswertes Berlin. Das CityLAB ist ein offener Ort zum Mitmachen! Wenn ihr mehr wissen wollt, schaut euch auf unserer Webseite um oder kommt einfach mal vorbei! <br /> <br /> Das CityLAB ist ein Projekt der Technologiestiftung Berlin und wird gefördert durch die Berliner Senatskanzlei. <br /> <br /> Du hast Feedback? Wir würden uns sehr darüber freuen, in unserem dafür eingerichteten <a target=\\"blank\\" href=\\"https://join.slack.com/t/giessdenkiez/shared_invite/zt-e3et281u-xON4UmBZpKavzDRkw5HmCQ\\">Slack-Kanal</a> von Dir zu hören.<br /> <br />Presseanfragen gehen am besten an:<br /> Frauke Nippel<br /><a href=\\"mailto:nippel@technologiestiftung-berlin.de?subject=giessdenkiez.de%20Presseanfrage\\">nippel@technologiestiftung-berlin.de</a><br />
@@ -773,12 +773,12 @@ exports[`Storyshots Sidebar About 1`] = `
       className="sc-AxgMl gOOTwl"
     >
       <span
-        className="sc-fzoPby sc-fzooss WWGlw"
+        className="sc-fzoPby sc-fzqyvX hEnIIm"
       >
         Datenquellen
       </span>
       <span
-        className="sc-fzpans sc-fzqyvX iicrtY"
+        className="sc-fzpans sc-fzqKVi gKkhAL"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Die Karte zeigt einen Großteil der Berliner Straßen- und Anlagenbäume (625.000; Stand: 14.06.2019). Zusätzlich wird abgebildet, wie viel Niederschlag in den letzten 30 Tagen bei jedem Baum gefallen ist und ob diese in der Zeit bereits gegossen wurden. Aus verschiedenen Gründen sind leider noch nicht alle Berliner Stadtbäume aufgeführt. Wir arbeiten aber daran, die Datenlage zu verbessern und eine möglichst vollständige Darstellung des Berliner Baumbestandes zu erreichen. Die aktuellen Datenquellen sind:
@@ -805,7 +805,7 @@ exports[`Storyshots Sidebar About 1`] = `
       F.A.Q.
     </h2>
     <span
-      className="sc-fzpans sc-fzqyvX iicrtY"
+      className="sc-fzpans sc-fzqKVi gKkhAL"
     >
       Basierend auf dem regen Austausch unserer Community auf Slack & euren Rückmeldungen per Email und Telefon, haben wir ein kleines FAQ angelegt. Hier werden die am häuftigsten gestellten Fragen beantwortet.
     </span>
@@ -839,7 +839,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Du bist einfach nur neugierig welcher Baum vor deiner Tür steht? Kein Problem: navigiere und zoome zum gewünschten Standort und klicke auf den farbigen Punkt. Nun werden dir im Menüband links zahlreiche Informationen zum ausgewählten Baum angezeigt. <br> <br> Du möchtest aktiv werden oder bist breits aktiv am Gießen? Dann kannst du hier einen oder mehrere Bäume adoptieren. Lege dazu zunächst ein Profil mit einer gültigen Email-Adresse an und logge dich im Anschluss ein. Nun kannst du deine Gieß-Aktionen entsprechend dokumentieren und sehen ob und wie oft Bäume in deinem Kiez bereits von anderen Nutzer*innen gegossen wurden.",
@@ -871,7 +871,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Wir beziehen den Baum-Datensatz mit allen Attributen wie bspw. Adresse, Baumart und Pflanzjahr je Baum aus dem Geoportal der Stadt Berlin, dem FIS-Broker. Die im Geoportal bereitgestellten Daten basieren wiederum auf den bezirklich aggregierten Daten der Straßen- und Grünflächenämter. Es kann daher immer wieder vorkommen, dass Daten von Bäumen veraltet sind oder Eigenschaften der tagesaktuellen Realität abweichen. <br><br> Wir arbeiten bereits an einer Idee, damit Bürger*innen Informationen zu Bäumen in Zukunft selbst melden können. Aktuell jedoch gibt es keinen solchen Meldedialog. Etwaige Abweichungen können direkt bei der zuständigen bezirklichen Behörde gemeldet werden.",
@@ -903,7 +903,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Die langanhaltenden Dürre- und Hitzeperioden der letzten zwei Jahre haben dem Stadtgrün Berlins immens zugesetzt. Wenngleich nicht nur auf Trockenschäden zurückzuführen, mussten allein in diesem Zeitraum über 7.000 Bäume gefällt werden. <br><br> Die Straßen- und Grünflächenämter sind bereits aktiv, kommen allerdings mit dem Gießen nicht hinterher. Da die Grünflächenämter bezirklich organisiert sind, arbeitet jeder Bezirk etwas anders, sodass eine ganzheitliche und bedarfsgerechte Koordination durchaus mit Hürden verbunden ist. Durch die Plattform möchten wir auch Bürger*innen die Möglichkeit geben, Bäumen gezielt auf Grundlage deren aktuellen Wasserversorgung zu helfen. Ziel ist es, möglichst viele Bäume durch nachbarschaftliches Engagement zu retten.",
@@ -935,7 +935,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Je nach Alter, Standort und Baumart benötigen Bäume unterschiedlich viel Wasser. Jungbäume <br> (0-15 Jahre), benötigen mehr Wasser als mittelalte Bäume (15-40 Jahre). Altbäume (ab 40 Jahre) sind meist komplette Selbstversorger. <br>Da frisch gepflanzte Bäume bis zum Alter von drei Jahren in der Regel von den bezirklichen Grünflächenämtern mit Wasser versorgt werden, benötigen besonders die Bäume zwischen vier und 15 Jahren unsere Aufmerksamkeit, beziehungsweise unser Wasser. Dies haben wir mit den Kennzeichungen des geringen, mittleren oder hohen Wasserbedarfs hervorgehoben.<br><br> Angelehnt an das Berliner <a traget=\\"blank\\" href=\\"https://www.berlin.de/senuvk/umwelt/stadtgruen/pflege_unterhaltung/de/hgp/index.shtml\\">Handbuch Gute Pflege</a> empfehlen wir euch, lieber seltener zu wässern, dafür mit einer größeren Menge an Wasser. Das Handbuch empfiehlt für frisch gepflanzte Bäume bis zu 200l pro Gießung. So sorgt ihr dafür, dass die Bodenfeuchte auch in der Tiefe erhöht wird. Im Endeffekt schaden aber auch kleinere Mengen gerade im Hochsommer nicht. Wichtig ist es, den ausgetrockneten Boden vor dem Gießen aufzulockern, sodass das Wasser in den Boden eindringen kann und nicht wegläuft oder sich falsch anstaut. Auch zu empfehlen sind sog. Gießsäcke aus denen das Wasser nur sehr langsam ausstritt, kaum oberflächig abläuft und somit kontinuierlich in den Boden sickert.",
@@ -967,7 +967,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Für die Infrastruktur der Straßen, zu denen auch die öffentlichen Schwengelpumpen zählen, sind die jeweiligen Straßen- und Grünflächenämter der Bezirke verantwortlich. Sollten Pumpen kaputt oder beschädigt sein, kann dort Reparaturbedarf gemeldet werden. Die Standorte der Pumpen in der Karte werden regelmäßig aus der Open Street Map geladen. Wenn Ihr helfen wollt die Daten zu verbessern, indem ihr zum Beispiel eine defekte Pumpe meldet, könnt ihr das in unserem <a target=\\"blank\\" href=\\"https://app.slack.com/client/T012K4SDYBY/C019SJQDPL7\\">Slack Channel #pumpen-melden </a>
@@ -1000,7 +1000,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Bei der Beteiligungsplattform “Giess den Kiez” handelt es sich um einen Prototypen, respektive um eine Beta-Version einer Web-App. Wir sind uns einigen technischen Hürden bewusst und wollen die Plattform in Zukunft performanter und stabiler gestalten, bitten euch aber diesbezüglich um etwas Geduld und Verständnis. <br><br> Euer technisches Feedback und eure Fragen nehmen wir gerne in unserem <a target=\\"blank\\" href=\\"https://join.slack.com/t/giessdenkiez/shared_invite/zt-e3et281u-xON4UmBZpKavzDRkw5HmCQ\\">Slack Channel</a> oder per Mail entgegen. Wer sich in der “Tech-Welt” zu Hause fühlt, ist herzlich zur Mitarbeit in unserem <a target=\\"blank\\" href=\\"https://github.com/technologiestiftung/giessdenkiez-de\\">Open Source GitHub Repository</a> eingeladen und kann seine Issues oder Code Fixes direkt in das Repository kommentieren.",
@@ -1032,7 +1032,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Wenn die Seite zum ersten Mal geöffnet wird, lädt der Browser über 625.000 Datenpunkte – das kann eine Weile dauern! Unabhängig davon, kann es zu leicht unterschiedlichen  Darstellungen bei der Verwendung unterschiedlicher Browser kommen. Für die beste “Experience” empfehlen wir die Nutzung des Chrome-Browsers am Desktop. Die häufigsten Probleme lassen sich erfahrungsgemäß beseitigen, wenn der Browser nicht veraltet, respektive die neueste Version installiert ist und eine stabile Internetverbindung (LAN oder WLAN) besteht. <br><br> Die Nutzung via Mobilfunknetz kann zu Performance-Problemen (Seite lädt langsam) führen. Sollten wiederholt Probleme auftreten, könnt ihr diese auf <a target=\\"blank\\" href=\\"https://join.slack.com/t/giessdenkiez/shared_invite/zt-e3et281u-xON4UmBZpKavzDRkw5HmCQ\\">Slack</a>, per Mail oder via GitHub Issue unter Angabe des benutzten Geräts, des Betriebssystems, des Browsers und Version des Browsers melden.",
@@ -1064,7 +1064,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Eine Funktion, um Gieß-Aktivitäten rückgängig zu machen, weil bspw. stattdessen der Nachbarbaum gegossen wurde, existiert leider nicht.",
@@ -1096,7 +1096,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Die “Gieß den Kiez” Plattform ist ein Open Source Software Projekt und läuft unter einer MIT Lizenz. Dementsprechend kann die Idee, aber auch der Quellcode für die Umsetzung in anderen Städten kostenlos genutzt und weiterentwickelt werden. Wenn Du dich dafür interessierst, schau gerne in unserem <a target=\\"blank\\" href=\\"https://github.com/technologiestiftung/giessdenkiez-de\\">GitHub Repository</a> vorbei oder kontaktiere uns via Mail.",
@@ -1128,7 +1128,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Das FAQ konnte dir nicht weiterhelfen oder du hast eine komplexere Anfrage? Dann schreib uns eine <a href=\\"mailto:giessdenkiez@citylab-berlin.org?subject=[Giess Den Kiez] Frage:...\\">Email.</a>",
@@ -1160,7 +1160,7 @@ exports[`Storyshots Sidebar About 1`] = `
         className="sc-Axmtr hyKxwW"
       >
         <span
-          className="sc-fzpans sc-fzqyvX iicrtY"
+          className="sc-fzpans sc-fzqKVi gKkhAL"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Gieß den Kiez is a participatory platform where you can inform yourself about the trees in your neighbourhood and their water needs. You can explore individual trees in Berlin and find out about the proper watering of trees. If you want to water the same trees regularly, you should create an account, adopt the trees and show that they are taken care of. This way, coordination takes place in the neighbourhood.",
@@ -1170,7 +1170,7 @@ exports[`Storyshots Sidebar About 1`] = `
       </div>
     </div>
     <div
-      className="sc-fzoCUK dlmyHH"
+      className="sc-fzoOEf dWJJDq"
     >
       <div
         className="sc-fzpdbB gHVowW"
@@ -1215,7 +1215,7 @@ exports[`Storyshots Sidebar About 1`] = `
       </div>
     </div>
     <div
-      className="sc-fzqKVi lhnvlF"
+      className="sc-fzoCUK hQzvpa"
     >
       <div
         className="sc-fznBtT gPiWoK"
@@ -1296,10 +1296,11 @@ exports[`Storyshots Sidebar About 1`] = `
       </div>
     </div>
     <div
-      className="sc-fzobTh eMxZy"
+      className="sc-fzobTh bNfoGN"
     >
       <img
         alt="GitHub Mark"
+        className="sc-fzooss kWJuPZ"
         src="/images/icon-github.svg"
       />
       <span
@@ -1320,10 +1321,10 @@ exports[`Storyshots Sidebar About 1`] = `
 
 exports[`Storyshots Sidebar Adopted 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -1345,7 +1346,7 @@ exports[`Storyshots Sidebar Adopted 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -1353,10 +1354,10 @@ exports[`Storyshots Sidebar Adopted 1`] = `
       Adoptierte Bäume:
     </h2>
     <div
-      className="sc-pJurq jPPjiU"
+      className="sc-pRTZB hjsgVq"
     >
       <div
-        className="sc-pAZqv kNInGk"
+        className="sc-pJurq fQCFvg"
       >
         <div
           className="double-bounce1"
@@ -1380,10 +1381,10 @@ exports[`Storyshots Sidebar Adopted 1`] = `
 
 exports[`Storyshots Sidebar Profile Logged In 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -1405,7 +1406,7 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -1413,7 +1414,7 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
       Profil
     </h2>
     <div
-      className="sc-pBzUF hzVIgL"
+      className="sc-pJUVA fAUyhs"
     >
       <p
         className="sc-fzoiQi bYPyvF"
@@ -1430,7 +1431,7 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
         Konto anlegen / Einloggen
       </div>
       <span
-        className="sc-fzpans sc-qQMSE fOVUrj"
+        className="sc-fzpans sc-qYIQh bilNww"
         onClick={[Function]}
       >
         Wie kann ich mitmachen?
@@ -1442,10 +1443,10 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
 
 exports[`Storyshots Sidebar Profile Logged Out 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -1467,7 +1468,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -1475,7 +1476,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
       Profil
     </h2>
     <div
-      className="sc-pBzUF hzVIgL"
+      className="sc-pJUVA fAUyhs"
     >
       <p
         className="sc-fzoiQi bYPyvF"
@@ -1492,7 +1493,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
         Konto anlegen / Einloggen
       </div>
       <span
-        className="sc-fzpans sc-qQMSE fOVUrj"
+        className="sc-fzpans sc-qYIQh bilNww"
         onClick={[Function]}
       >
         Wie kann ich mitmachen?
@@ -1504,10 +1505,10 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
 
 exports[`Storyshots Sidebar Search 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -1529,7 +1530,7 @@ exports[`Storyshots Sidebar Search 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -1537,67 +1538,67 @@ exports[`Storyshots Sidebar Search 1`] = `
       Suche & Filter
     </h2>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Datenansicht
       </span>
       <span
-        className="sc-fzpans sc-pANHa haFDkS"
+        className="sc-fzpans sc-pIJJz hVrhAz"
       >
         Betrachte welche Bäume bereits von anderen Nutzern gegossen wurden. Oder finde heraus, wieviel Niederschlag die Bäume in den letzten 30 Tagen erreicht hat.
       </span>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq gBcOGu"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP kSHMtR"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           Niederschläge
         </label>
       </div>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq hxvpuJ"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP dbUQVK"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           Bereits adoptiert
         </label>
       </div>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq hxvpuJ"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP dbUQVK"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           In den letzten 30 Tagen gegossen
         </label>
       </div>
     </div>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Baumalter
       </span>
       <span
-        className="sc-fzpans sc-pANHa haFDkS"
+        className="sc-fzpans sc-pIJJz hVrhAz"
       >
         Erkunde die Geschichte von Berlins Baumlandschaft
       </span>
       <div
-        className="sc-fzoOEf LVKyS"
+        className="sc-fzpdyU coLgpR"
       >
         <span
-          className="sc-fzppip khzuLq"
+          className="sc-fznBMq dZCfpb"
         >
           0
            - 
@@ -1605,7 +1606,7 @@ exports[`Storyshots Sidebar Search 1`] = `
            Jahre
         </span>
         <div
-          className="sc-fzpdyU dacGCY"
+          className="sc-fzppip hhgeth"
         >
           <div
             className="rc-slider rc-slider-with-marks"
@@ -1795,18 +1796,18 @@ exports[`Storyshots Sidebar Search 1`] = `
       </div>
     </div>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Standortsuche
       </span>
       <div
-        className="sc-fznBMq iOKdOv"
+        className="sc-fznNvL gLgVaF"
       >
         <div
-          className="sc-fznNvL pjMaa"
+          className="sc-fzocqA fqUkAE"
         >
           <input
             onChange={[Function]}
@@ -1816,7 +1817,7 @@ exports[`Storyshots Sidebar Search 1`] = `
           />
         </div>
         <div
-          className="sc-fzocqA cgsLXo"
+          className="sc-fzonZV hvhTp"
         >
           <ul />
         </div>
@@ -1828,10 +1829,10 @@ exports[`Storyshots Sidebar Search 1`] = `
 
 exports[`Storyshots Sidebar Search Location 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pZOBi bFyCjy"
 >
   <a
-    className="sc-pJUVA gKpAlB"
+    className="sc-pRtAn fENRnc"
     href="/"
     onClick={[Function]}
   >
@@ -1853,7 +1854,7 @@ exports[`Storyshots Sidebar Search Location 1`] = `
     </button>
   </a>
   <div
-    className="sc-pZOBi eyLUVw"
+    className="sc-oTNDV bgOgXx"
   >
     <h2
       className="sc-fzoCCn hqNcCS"
@@ -1861,67 +1862,67 @@ exports[`Storyshots Sidebar Search Location 1`] = `
       Suche & Filter
     </h2>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Datenansicht
       </span>
       <span
-        className="sc-fzpans sc-pANHa haFDkS"
+        className="sc-fzpans sc-pIJJz hVrhAz"
       >
         Betrachte welche Bäume bereits von anderen Nutzern gegossen wurden. Oder finde heraus, wieviel Niederschlag die Bäume in den letzten 30 Tagen erreicht hat.
       </span>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq gBcOGu"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP kSHMtR"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           Niederschläge
         </label>
       </div>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq hxvpuJ"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP dbUQVK"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           Bereits adoptiert
         </label>
       </div>
       <div
-        className="sc-fzqyOu sc-pZBmh sc-oTbqq hxvpuJ"
+        className="sc-fzqKxP sc-oTbqq sc-paXsP dbUQVK"
         onClick={[Function]}
       >
         <label
-          className="sc-pIJJz sc-pRFjI iktqoh"
+          className="sc-pRFjI sc-pZBmh dwenUT"
         >
           In den letzten 30 Tagen gegossen
         </label>
       </div>
     </div>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Baumalter
       </span>
       <span
-        className="sc-fzpans sc-pANHa haFDkS"
+        className="sc-fzpans sc-pIJJz hVrhAz"
       >
         Erkunde die Geschichte von Berlins Baumlandschaft
       </span>
       <div
-        className="sc-fzoOEf LVKyS"
+        className="sc-fzpdyU coLgpR"
       >
         <span
-          className="sc-fzppip khzuLq"
+          className="sc-fznBMq dZCfpb"
         >
           0
            - 
@@ -1929,7 +1930,7 @@ exports[`Storyshots Sidebar Search Location 1`] = `
            Jahre
         </span>
         <div
-          className="sc-fzpdyU dacGCY"
+          className="sc-fzppip hhgeth"
         >
           <div
             className="rc-slider rc-slider-with-marks"
@@ -2119,18 +2120,18 @@ exports[`Storyshots Sidebar Search Location 1`] = `
       </div>
     </div>
     <div
-      className="sc-fzqyOu gqHbzu"
+      className="sc-fzqKxP fkGcui"
     >
       <span
-        className="sc-fzpans sc-fzqKxP kfKHxs"
+        className="sc-fzpans sc-pANHa ciOPdk"
       >
         Standortsuche
       </span>
       <div
-        className="sc-fznBMq iOKdOv"
+        className="sc-fznNvL gLgVaF"
       >
         <div
-          className="sc-fznNvL pjMaa"
+          className="sc-fzocqA fqUkAE"
         >
           <input
             onChange={[Function]}
@@ -2140,7 +2141,7 @@ exports[`Storyshots Sidebar Search Location 1`] = `
           />
         </div>
         <div
-          className="sc-fzocqA cgsLXo"
+          className="sc-fzonZV hvhTp"
         >
           <ul />
         </div>

--- a/src/components/OpenSource/index.tsx
+++ b/src/components/OpenSource/index.tsx
@@ -6,20 +6,22 @@ import CardDescription from '../Card/CardDescription';
 const iconGithub = '/images/icon-github.svg';
 
 const OpenSourceContainer = styled.div`
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: 12px;
   margin-bottom: 10px;
-
-  img {
-    width: 16px;
-    height: auto;
-    margin-right: 5px;
-  }
+  place-items: center;
 `;
+
+const GithubIcon = styled.img`
+  width: 16px;
+  height: 16px;
+`
 
 const OpenSourceNote = () => {
   return (
     <OpenSourceContainer>
-      <img alt='GitHub Mark' src={iconGithub} />
+	  <GithubIcon alt='GitHub Mark' src={iconGithub} />
       <CardDescription>
         Giess den Kiez ist ein&nbsp;
         <a


### PR DESCRIPTION
The image had to be limited to its container. Hardcoded the size of the icon to 16x16px and made
the container a grid container.

This fixes #173