### PR TITLE
Fix #253: About sidebar on mobile has an horizontal scrollbar

### DIFF
--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -685,7 +685,7 @@ exports[`Storyshots Overlay Legend Story 1`] = `
 
 exports[`Storyshots Sidebar About 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -713,7 +713,7 @@ exports[`Storyshots Sidebar About 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Weitere Infos
     </h2>
@@ -800,7 +800,7 @@ exports[`Storyshots Sidebar About 1`] = `
       />
     </div>
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       F.A.Q.
     </h2>
@@ -1320,7 +1320,7 @@ exports[`Storyshots Sidebar About 1`] = `
 
 exports[`Storyshots Sidebar Adopted 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -1348,7 +1348,7 @@ exports[`Storyshots Sidebar Adopted 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Adoptierte Bäume:
     </h2>
@@ -1380,7 +1380,7 @@ exports[`Storyshots Sidebar Adopted 1`] = `
 
 exports[`Storyshots Sidebar Profile Logged In 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -1408,7 +1408,7 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Profil
     </h2>
@@ -1442,7 +1442,7 @@ exports[`Storyshots Sidebar Profile Logged In 1`] = `
 
 exports[`Storyshots Sidebar Profile Logged Out 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -1470,7 +1470,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Profil
     </h2>
@@ -1504,7 +1504,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
 
 exports[`Storyshots Sidebar Search 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -1532,7 +1532,7 @@ exports[`Storyshots Sidebar Search 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Suche & Filter
     </h2>
@@ -1828,7 +1828,7 @@ exports[`Storyshots Sidebar Search 1`] = `
 
 exports[`Storyshots Sidebar Search Location 1`] = `
 <div
-  className="sc-pRtAn fLWcwd"
+  className="sc-pRtAn iWNjrd"
 >
   <a
     className="sc-pJUVA gKpAlB"
@@ -1856,7 +1856,7 @@ exports[`Storyshots Sidebar Search Location 1`] = `
     className="sc-pZOBi eyLUVw"
   >
     <h2
-      className="sc-fzoCCn hqNcCS"
+      className="sc-fzoCCn OrWQc"
     >
       Suche & Filter
     </h2>

--- a/src/components/Sidebar/SidebarTitle/index.tsx
+++ b/src/components/Sidebar/SidebarTitle/index.tsx
@@ -4,7 +4,6 @@ const SidebarTitle = styled.h2`
   font-size: ${p => p.theme.fontSizeXxl};
   font-weight: bold;
   margin: 20px 0 10px;
-  width: 300px;
 `;
 
 export default SidebarTitle;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -14,7 +14,8 @@ interface StyledProps {
 const SidebarWrapper = styled.div<StyledProps>`
   z-index: 3;
   position: absolute;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   display: block;
   transform: ${props =>
     props.isVisible


### PR DESCRIPTION
1. Add `overflow-x: hidden;` and `overflow-y: auto;` on sidebar container
2. Remove hard-coded width of sidebar title (Provoking overflow)

Fixes #253