### PR TITLE
fix(filters): display adopted & watered trees on mobile

### DIFF
--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -382,6 +382,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         type: 'circle',
         source: 'trees',
         'source-layer': 'original',
+        // TODO: Below we add the style for the trees on mobile. The color updates should be inserted or replicated here.
         paint: {
           'circle-radius': {
             base: 1.75,
@@ -456,7 +457,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         const filter = [
           'match',
           ['get', 'id'],
-          this.props.communityData?.wateredTreesIds,
+          this.props.communityDataWatered,
           true,
           false,
         ];
@@ -465,7 +466,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         const filter = [
           'match',
           ['get', 'id'],
-          this.props.communityData?.adoptedTreesIds,
+          this.props.communityDataAdopted,
           true,
           false,
         ];


### PR DESCRIPTION
This PR fixes the bug that on mobile watered and adopted trees were not displayed when their respective filter was applied.

The bug originates from undefined data being passed into the filter in the `_updateStyles` method which is only called if the device `isMobile`. That's why non-mobile devices were not affected. Their display is handled in a [layer](https://github.com/technologiestiftung/giessdenkiez-de/blob/d426fcc028ad29c6b1b27393ff646e7293877126/src/components/TreesMap/DeckGLMap.tsx#L120) that is not displayed on mobile, see [here](https://github.com/technologiestiftung/giessdenkiez-de/blob/d426fcc028ad29c6b1b27393ff646e7293877126/src/components/TreesMap/DeckGLMap.tsx#L172).

A note was added that indicates where color updates of the circles would be handled for mobile. As this is not scope of this issue, I have not tackled it.