### PR TITLE
fix(filter): make tree age filter work

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -70,7 +70,8 @@ export interface Tree {
   hausnr?: string | null;
   zusatz?: string | null;
   pflanzjahr?: string | null;
-  standalter?: string | null;
+  standalter?: string | null; // this may be redundant now, but I'm not entirely sure
+  age?: string;
   kronedurch?: string | null;
   stammumfg?: string | null;
   type?: string | null;
@@ -85,6 +86,11 @@ export interface Tree {
   standortnr?: string | null;
   kennzeich?: string | null;
   caretaker?: string | null;
+}
+
+export interface TreeGeojsonFeatureProperties
+  extends Pick<Tree, 'id' | 'radolan_sum'> {
+  age?: number;
 }
 
 type TreeId = string;

--- a/src/utils/requests/loadTreesGeoJson.ts
+++ b/src/utils/requests/loadTreesGeoJson.ts
@@ -1,6 +1,6 @@
-import { dsv as d3Dsv } from 'd3';
+import { dsv as d3Dsv, GeoGeometryObjects } from 'd3';
 import { ExtendedFeatureCollection, ExtendedFeature } from 'd3-geo';
-import { Tree } from '../../common/interfaces';
+import { Tree, TreeGeojsonFeatureProperties } from '../../common/interfaces';
 
 function createGeojson(trees: Tree[]): ExtendedFeatureCollection {
   const geojson: ExtendedFeatureCollection = {
@@ -9,7 +9,10 @@ function createGeojson(trees: Tree[]): ExtendedFeatureCollection {
   };
 
   trees.forEach(tree => {
-    const feature: ExtendedFeature = {
+    const feature: ExtendedFeature<
+      GeoGeometryObjects | null,
+      TreeGeojsonFeatureProperties
+    > = {
       type: 'Feature',
       geometry: {
         type: 'Point',
@@ -27,7 +30,7 @@ function createGeojson(trees: Tree[]): ExtendedFeatureCollection {
       properties: {
         id: tree.id,
         radolan_sum: (tree?.radolan_sum || 0) / 10,
-        age: +(tree?.standalter || 0),
+        age: tree?.age ? parseInt(tree.age) : undefined,
       },
     };
     geojson.features.push(feature);


### PR DESCRIPTION
The PR addresses the bug that no trees were displayed when changing the age filter on non-mobile devices (mobile devices were not affected because they pull a different dataset).

The bug was caused by an inexistent key `standalter` that we were trying to assign to our `age` field in the GeoJSON property. The key that **is** existent in the data source is called `age` as well.

The [fix](https://github.com/technologiestiftung/giessdenkiez-de/blob/114740744af19b55f92dcd44f3d732021b9cf5c1/src/utils/requests/loadTreesGeoJson.ts#L33) in this PR is to change the key from `standalter` to `age`. Also, some typing is added, so that confusion is hopefully mitigated in the future.