### PR TITLE
fix(GDK-130): hide trees with unknown age when age filter is applied

### DIFF
--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -93,7 +93,7 @@ const TreeInfos: FC<{
 }> = ({ selectedTreeData }) => {
   const {
     id: treeId,
-    standalter,
+    pflanzjahr,
     artdtsch,
     gattungdeutsch,
     caretaker,
@@ -112,6 +112,11 @@ const TreeInfos: FC<{
 
   const treeIsAdopted =
     userData && userData.adoptedTrees.find(({ id }) => id === treeId);
+
+  const treeAge =
+    pflanzjahr && pflanzjahr !== 'undefined' && pflanzjahr !== 'NaN'
+      ? new Date().getFullYear() - parseInt(pflanzjahr, 10)
+      : undefined;
 
   return (
     <Wrapper>
@@ -141,19 +146,17 @@ const TreeInfos: FC<{
             {treeType.description}
           </ExpandablePanel>
         )}
-        {standalter && standalter !== 'undefined' && (
+        {treeAge && (
           <>
             <AgeInfoContainer>
               <span>Standalter</span>
-              <AgeInfoValue>{standalter} Jahre</AgeInfoValue>
+              <AgeInfoValue>{treeAge} Jahre</AgeInfoValue>
             </AgeInfoContainer>
             <ExpandablePanel
               title={
                 <>
                   <span style={{ marginRight: 8 }}>Wasserbedarf:</span>
-                  <WaterDrops
-                    dropsAmount={getWaterNeedByAge(parseInt(standalter))}
-                  />
+                  <WaterDrops dropsAmount={getWaterNeedByAge(treeAge)} />
                 </>
               }
             >

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -173,7 +173,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
             turquoise: [0, 128, 128, 200] as [number, number, number, number],
           };
 
-          const rainDataExists = radolan_sum;
+          const rainDataExists = !!radolan_sum;
 
           const ageFilterIsApplied =
             minFilteredAge !== 0 || maxFilteredAge !== 320; // TODO: how to not hard-code these values?

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -187,7 +187,9 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
               !ageFilterIsApplied);
 
           const colorShallBeTransparent =
-            (ageFilterIsApplied && !treeAge) || !rainDataExists;
+            (ageFilterIsApplied && !treeAge) ||
+            (ageFilterIsApplied && !treeIsWithinAgeRange) ||
+            !rainDataExists;
 
           if (colorShallBeTransparent) return colors.transparent;
 


### PR DESCRIPTION
This PR updates the age filter so that when any age filtering is applied, trees with unknown age disappear. This makes sense from a UX perspective as the user explicitly selects a desired range and may be confused if they see trees without any age in the remaining collection.

Additionally, the displayed individual tree age in the sidebar is adjusted and now calculated by doing `new Date().getFullYear() - parseInt(pflanzjahr, 10)`. This is because the previously used `standalter` value does not seem to be updated anymore and was behind by 2 years. The `pflanzjahr` seems like a more reliable data point here and is now in sync with the actual age and the filter.

---

Note: The filter update is only for non-mobile devices! We use a different vector tile dataset for trees on mobile and trees without age are not displayed there at all. We should investigate this separately.