### PR TITLE
feat(GDK-19): extended tooltip

### DIFF
--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -8444,75 +8444,226 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
 </div>
 `;
 
-exports[`Storyshots Tooltip With React Children 1`] = `
-<div>
-  <div
-    className="sc-bQdQlF fyYMOo tooltip"
-    height={0}
-    width={0}
-    x={200}
-    y={150}
+exports[`Storyshots Tooltip Default 1`] = `
+<div
+  className="sc-jGVbCA gAKAyi"
+>
+  <header
+    className="sc-bQdQlF liHyzl"
   >
-    <span
-      className="sc-jGVbCA WykgY"
+    <h3
+      className="sc-fXoxut hmiKgb"
     >
-      <b>
-        Bold and sweaty
-      </b>
-       
-      <div
-        className="sc-bTvRPi jNQdyT"
-      >
-        <svg
-          height="14px"
-          viewBox="0 0 9 14"
-          width="9px"
-        >
-          <g
-            fill="#75ADE8"
-            id="water-drop"
-          >
-            <path
-              d="M4.5,14 C6.98528137,14 9,11.8235471 9,9.13875632 C9,6.45396557 4.5,0 4.5,0 C4.5,0 0,6.45396557 0,9.13875632 C0,11.8235471 2.01471863,14 4.5,14 Z"
-              id="water-drop-path"
-            />
-          </g>
-        </svg>
-        <svg
-          height="14px"
-          viewBox="0 0 9 14"
-          width="9px"
-        >
-          <g
-            fill="#75ADE8"
-            id="water-drop"
-          >
-            <path
-              d="M4.5,14 C6.98528137,14 9,11.8235471 9,9.13875632 C9,6.45396557 4.5,0 4.5,0 C4.5,0 0,6.45396557 0,9.13875632 C0,11.8235471 2.01471863,14 4.5,14 Z"
-              id="water-drop-path"
-            />
-          </g>
-        </svg>
-      </div>
-    </span>
+      This is a title
+    </h3>
+  </header>
+  <div
+    className="sc-eFubAy cyCewY"
+  >
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
   </div>
 </div>
 `;
 
-exports[`Storyshots Tooltip With Text String 1`] = `
-<div>
-  <div
-    className="sc-bQdQlF hgvoWR tooltip"
-    height={0}
-    width={0}
-    x={100}
-    y={100}
+exports[`Storyshots Tooltip With Subtitle 1`] = `
+<div
+  className="sc-jGVbCA gAKAyi"
+>
+  <header
+    className="sc-bQdQlF liHyzl"
   >
-    <span
-      className="sc-jGVbCA WykgY"
+    <h3
+      className="sc-fXoxut hmiKgb"
     >
-      This is a tooltip
-    </span>
+      This is a title
+    </h3>
+    <h4
+      className="sc-Fyfyc kYFDqc"
+    >
+      Subtitle
+    </h4>
+  </header>
+  <div
+    className="sc-eFubAy cyCewY"
+  >
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Tooltip With Subtitle And Children 1`] = `
+<div
+  className="sc-jGVbCA gAKAyi"
+>
+  <header
+    className="sc-bQdQlF liHyzl"
+  >
+    <h3
+      className="sc-fXoxut hmiKgb"
+    >
+      This is a title
+    </h3>
+    <h4
+      className="sc-Fyfyc kYFDqc"
+    >
+      Subtitle
+    </h4>
+    <div
+      className="sc-jXktwP fnxDQO"
+    >
+      <span>
+        Here be React children.
+      </span>
+    </div>
+  </header>
+  <div
+    className="sc-eFubAy cyCewY"
+  >
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
+exports[`Storyshots Tooltip Without Subtitle And With Children 1`] = `
+<div
+  className="sc-jGVbCA gAKAyi"
+>
+  <header
+    className="sc-bQdQlF liHyzl"
+  >
+    <h3
+      className="sc-fXoxut hmiKgb"
+    >
+      This is a title
+    </h3>
+    <div
+      className="sc-jXktwP fnxDQO"
+    >
+      <span>
+        Here be React children.
+      </span>
+    </div>
+  </header>
+  <div
+    className="sc-eFubAy cyCewY"
+  >
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-fmlJLJ eQaNGi"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
   </div>
 </div>
 `;

--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -471,18 +471,242 @@ Array [
 ]
 `;
 
+exports[`Storyshots DataTable Default 1`] = `
+<div
+  className="sc-eCssSg ftSzBv"
+>
+  <header
+    className="sc-jSgupP iUjCLu"
+  >
+    <h3
+      className="sc-gKsewC czodJZ"
+    >
+      This is a title
+    </h3>
+  </header>
+  <div
+    className="sc-pFZIQ ksLDOc"
+  >
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DataTable With Subtitle 1`] = `
+<div
+  className="sc-eCssSg ftSzBv"
+>
+  <header
+    className="sc-jSgupP iUjCLu"
+  >
+    <h3
+      className="sc-gKsewC czodJZ"
+    >
+      This is a title
+    </h3>
+    <h4
+      className="sc-iBPRYJ jsXiGR"
+    >
+      Subtitle
+    </h4>
+  </header>
+  <div
+    className="sc-pFZIQ ksLDOc"
+  >
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DataTable With Subtitle And Children 1`] = `
+<div
+  className="sc-eCssSg ftSzBv"
+>
+  <header
+    className="sc-jSgupP iUjCLu"
+  >
+    <h3
+      className="sc-gKsewC czodJZ"
+    >
+      This is a title
+    </h3>
+    <h4
+      className="sc-iBPRYJ jsXiGR"
+    >
+      Subtitle
+    </h4>
+    <div
+      className="sc-fubCfw cRYdgb"
+    >
+      <span>
+        Here be React children.
+      </span>
+    </div>
+  </header>
+  <div
+    className="sc-pFZIQ ksLDOc"
+  >
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
+exports[`Storyshots DataTable Without Subtitle And With Children 1`] = `
+<div
+  className="sc-eCssSg ftSzBv"
+>
+  <header
+    className="sc-jSgupP iUjCLu"
+  >
+    <h3
+      className="sc-gKsewC czodJZ"
+    >
+      This is a title
+    </h3>
+    <div
+      className="sc-fubCfw cRYdgb"
+    >
+      <span>
+        Here be React children.
+      </span>
+    </div>
+  </header>
+  <div
+    className="sc-pFZIQ ksLDOc"
+  >
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Status
+      </th>
+      <td>
+        Unknown
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Last update
+      </th>
+      <td>
+        Yesterday
+      </td>
+    </tr>
+    <tr
+      className="sc-jrAGrp hBErSp"
+    >
+      <th>
+        Type
+      </th>
+      <td>
+        Random type
+      </td>
+    </tr>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Legend Legend Story 1`] = `
 <div
-  className="sc-fodVxV kEJMiO"
+  className="sc-kfzAmx jKLOHQ"
 >
   <div
-    className="sc-pFZIQ juxTNt"
+    className="sc-kstrdz fWySel"
   >
     <div
-      className="sc-eCssSg gOBaBp"
+      className="sc-kEjbxe fMmHxM"
     >
       <p
-        className="sc-gsTCUz iiIrBj sc-fFubgz jxTPMz"
+        className="sc-gsTCUz iiIrBj sc-fKFyDc euaybk"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Niederschlag",
@@ -501,99 +725,99 @@ exports[`Storyshots Legend Legend Story 1`] = `
       />
     </div>
     <span
-      className="sc-bkzZxe fVhioj"
+      className="sc-bBXqnf gQBYMC"
       onClick={[Function]}
     >
       —
     </span>
   </div>
   <div
-    className="sc-jSgupP cnVnvY"
+    className="sc-iqHYGH ioxsaR"
   >
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI kjchVc"
+        className="sc-bkzZxe hdmgPb"
         color="#fde725"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         0
       </label>
     </div>
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI kzicCy"
+        className="sc-bkzZxe gQlred"
         color="#cae11f"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         60
       </label>
     </div>
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI emtKJb"
+        className="sc-bkzZxe jaxGgE"
         color="#95d840"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         120
       </label>
     </div>
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI kbvRts"
+        className="sc-bkzZxe WCzHr"
         color="#63cb5f"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         180
       </label>
     </div>
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI iRoifw"
+        className="sc-bkzZxe dQBLDD"
         color="#3bbb75"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         240
       </label>
     </div>
     <div
-      className="sc-iBPRYJ kYgBLy"
+      className="sc-dQppl cbBAhJ"
     >
       <div
-        className="sc-crrsfI bjnxMu"
+        className="sc-bkzZxe jmrLJ"
         color="#22a884"
       />
       <label
-        className="sc-jrAGrp cKGRcl"
+        className="sc-hBEYos duqrtj"
       >
         300
       </label>
     </div>
   </div>
   <div
-    className="sc-eCssSg icVmlH"
+    className="sc-kEjbxe goAPHW"
   >
     <p
-      className="sc-gsTCUz iiIrBj sc-fFubgz jxTPMz"
+      className="sc-gsTCUz iiIrBj sc-fKFyDc euaybk"
       dangerouslySetInnerHTML={
         Object {
           "__html": "Datenpunkte",
@@ -611,41 +835,41 @@ exports[`Storyshots Legend Legend Story 1`] = `
       onClick={[Function]}
     />
     <div
-      className="sc-jSgupP sc-fubCfw cnVnvY dctumz"
+      className="sc-iqHYGH sc-bqyKva ioxsaR tIDOS"
       onClick={[Function]}
     >
       <div
-        className="sc-crrsfI feAbgj legend-dot"
+        className="sc-bkzZxe cxrzOk legend-dot"
         color="#2c303b"
       />
       <label
-        className="sc-jrAGrp sc-hBEYos cKGRcl gvQEzI"
+        className="sc-hBEYos sc-dmlrTW duqrtj bJfeJm"
       >
         Straßen- & Anlagenbäume
       </label>
     </div>
     <div
-      className="sc-jSgupP sc-fubCfw cnVnvY fOaPqU"
+      className="sc-iqHYGH sc-bqyKva ioxsaR gqKpNp"
       onClick={[Function]}
     >
       <div
-        className="sc-iqHYGH ciYaFs"
+        className="sc-fFubgz eldMfo"
       />
       <label
-        className="sc-jrAGrp sc-hBEYos cKGRcl gvQEzI"
+        className="sc-hBEYos sc-dmlrTW duqrtj bJfeJm"
       >
         Öffentl. Pumpen
       </label>
     </div>
     <div
-      className="sc-jSgupP sc-fubCfw cnVnvY fOaPqU"
+      className="sc-iqHYGH sc-bqyKva ioxsaR gqKpNp"
       onClick={[Function]}
     >
       <div
-        className="sc-dQppl cSJegs"
+        className="sc-idOhPF eALlHl"
       />
       <label
-        className="sc-jrAGrp sc-hBEYos cKGRcl gvQEzI"
+        className="sc-hBEYos sc-dmlrTW duqrtj bJfeJm"
       >
         Niederschlagsflächen
       </label>
@@ -1104,22 +1328,22 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-cBNfnY fCTIHy"
+    className="sc-cTkwdZ hJhrUF"
   >
     <div
-      className="sc-gWHgXt kqOxfX"
+      className="sc-eggNIi bNbJeD"
     >
       <div
-        className="sc-citwmv bOiXC"
+        className="sc-jNMdTA fPbMjg"
       >
         <div
-          className="sc-giIncl gXgjfs"
+          className="sc-gWHgXt hFEVXp"
         >
           <div
-            className="sc-iJuUWI heShFu"
+            className="sc-hiSbYr cahkwE"
           >
             <h2
-              className="sc-idOhPF UOyqT"
+              className="sc-iwyYcG hibBuR"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<b>Gieß den <span>Kiez</span></b>",
@@ -1128,15 +1352,15 @@ Array [
               size="xxl"
             />
             <div
-              className="sc-hHftDr ddCSLS"
+              className="sc-lmoMRL gVOsiP"
             >
               <img
-                className="sc-dmlrTW iHPMlG"
+                className="sc-iJuUWI fIDorH"
                 src="/images/icon-trees.svg"
               />
             </div>
             <div
-              className="sc-kfzAmx fIlFId"
+              className="sc-giIncl iJFfQM"
             >
               <span>
                 BETA
@@ -1144,7 +1368,7 @@ Array [
             </div>
           </div>
           <h2
-            className="sc-idOhPF UOyqT"
+            className="sc-iwyYcG hibBuR"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "Die Berliner Stadtbäume leiden unter Trockenheit <br class=\\"large\\" /> und Du kannst ihnen helfen!",
@@ -1154,10 +1378,10 @@ Array [
           />
           
           <div
-            className="sc-iwyYcG epjKMF"
+            className="sc-kLgntA ekPYbI"
           >
             <p
-              className="sc-fKFyDc hpBGMv sc-bBXqnf kzIRxT"
+              className="sc-ezrdKe fxCTcN sc-bYEvPH kNyRLK"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Auf dieser Plattform kannst Du Dich über Bäume in deiner Nachbarschaft und ihren Wasserbedarf informieren. Du kannst einzelne Bäume adoptieren und markieren, wenn Du sie gegossen hast.",
@@ -1166,7 +1390,7 @@ Array [
               onClick={[Function]}
             />
             <p
-              className="sc-fKFyDc hpBGMv sc-bBXqnf kzIRxT"
+              className="sc-ezrdKe fxCTcN sc-bYEvPH kNyRLK"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Informiere Dich ich über das richtige Gießen von Stadtbäumen. Wenn Du die Seite regelmäßig nutzen möchtest, solltest Du ein Konto erstellen. Die Karte kannst Du aber auch ohne Konto erkunden.",
@@ -1177,7 +1401,7 @@ Array [
           </div>
           <button
             aria-label="Leiste schließen"
-            className="sc-cxFLnm sc-lmoMRL kdoGKp ehGQOe"
+            className="sc-iktFzd sc-jJEJSO kagoRh AhzRE"
             onClick={[Function]}
             title="Leiste schließen"
           >
@@ -1193,7 +1417,7 @@ Array [
             </svg>
           </button>
           <div
-            className="sc-ezrdKe libGYC"
+            className="sc-cBNfnY lewUVX"
           >
             <div
               className="sc-bdfBwQ bOVEvz"
@@ -1216,7 +1440,7 @@ Array [
             </div>
           </div>
           <h2
-            className="sc-idOhPF jSSeht"
+            className="sc-iwyYcG dZqoqz"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "News & Updates",
@@ -1225,10 +1449,10 @@ Array [
             size="xl"
           />
           <div
-            className="sc-iwyYcG epjKMF"
+            className="sc-kLgntA ekPYbI"
           >
             <p
-              className="sc-fKFyDc hpBGMv sc-bBXqnf kzIRxT"
+              className="sc-ezrdKe fxCTcN sc-bYEvPH kNyRLK"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "Der Frühling kann kommen! Wir haben unser Backlog aufgeräumt, einige Funktionen verbessert und neue Funktionen hinzugefügt. Die wichtigsten Verbesserungen im Überblick:<br />
@@ -1248,7 +1472,7 @@ Array [
               onClick={[Function]}
             />
             <p
-              className="sc-fKFyDc hpBGMv sc-bBXqnf kzIRxT"
+              className="sc-ezrdKe fxCTcN sc-bYEvPH kNyRLK"
               dangerouslySetInnerHTML={
                 Object {
                   "__html": "<div style=\\"padding-top:0.5rem;padding-bottom:0.5rem; display:flex\\">
@@ -1268,10 +1492,10 @@ Array [
           </div>
         </div>
         <div
-          className="sc-hiSbYr fhoQTl"
+          className="sc-iBaPrD hLdkZC"
         >
           <h2
-            className="sc-idOhPF jSSeht"
+            className="sc-iwyYcG dZqoqz"
             dangerouslySetInnerHTML={
               Object {
                 "__html": "<b>Wie kann ich mitmachen?</b>",
@@ -1279,24 +1503,24 @@ Array [
             }
           />
           <div
-            className="sc-jJEJSO eLZHJD"
+            className="sc-iUuytg eCUoH"
           >
             <div
-              className="sc-bYEvPH jlxcTN"
+              className="sc-citwmv cjgDpT"
             >
               <div
-                className="sc-hHftDr ddCSLS"
+                className="sc-lmoMRL gVOsiP"
               >
                 <img
-                  className="sc-dmlrTW iHPMlG"
+                  className="sc-iJuUWI fIDorH"
                   src="/images/icon-water.svg"
                 />
               </div>
               <div
-                className="sc-kLgntA kSrRCm"
+                className="sc-jcVebW fVrLDe"
               >
                 <h2
-                  className="sc-iktFzd jYaEqu"
+                  className="sc-bZSQDF brBbuc"
                 >
                   Bäume bewässern
                 </h2>
@@ -1312,21 +1536,21 @@ Array [
               </div>
             </div>
             <div
-              className="sc-bYEvPH jlxcTN"
+              className="sc-citwmv cjgDpT"
             >
               <div
-                className="sc-hHftDr ddCSLS"
+                className="sc-lmoMRL gVOsiP"
               >
                 <img
-                  className="sc-dmlrTW iHPMlG"
+                  className="sc-iJuUWI fIDorH"
                   src="/images/icon-subscribe.svg"
                 />
               </div>
               <div
-                className="sc-kLgntA kSrRCm"
+                className="sc-jcVebW fVrLDe"
               >
                 <h2
-                  className="sc-iktFzd jYaEqu"
+                  className="sc-bZSQDF brBbuc"
                 >
                   Bäume adoptieren
                 </h2>
@@ -1342,21 +1566,21 @@ Array [
               </div>
             </div>
             <div
-              className="sc-bYEvPH jlxcTN"
+              className="sc-citwmv cjgDpT"
             >
               <div
-                className="sc-hHftDr ddCSLS"
+                className="sc-lmoMRL gVOsiP"
               >
                 <img
-                  className="sc-dmlrTW iHPMlG"
+                  className="sc-iJuUWI fIDorH"
                   src="/images/icon-zoom.svg"
                 />
               </div>
               <div
-                className="sc-kLgntA kSrRCm"
+                className="sc-jcVebW fVrLDe"
               >
                 <h2
-                  className="sc-iktFzd jYaEqu"
+                  className="sc-bZSQDF brBbuc"
                 >
                   Den Baumbestand erkunden
                 </h2>
@@ -1372,21 +1596,21 @@ Array [
               </div>
             </div>
             <div
-              className="sc-bYEvPH jlxcTN"
+              className="sc-citwmv cjgDpT"
             >
               <div
-                className="sc-hHftDr ddCSLS"
+                className="sc-lmoMRL gVOsiP"
               >
                 <img
-                  className="sc-dmlrTW iHPMlG"
+                  className="sc-iJuUWI fIDorH"
                   src="/images/icon-info.svg"
                 />
               </div>
               <div
-                className="sc-kLgntA kSrRCm"
+                className="sc-jcVebW fVrLDe"
               >
                 <h2
-                  className="sc-iktFzd jYaEqu"
+                  className="sc-bZSQDF brBbuc"
                 >
                   Mit anderen austauschen
                 </h2>
@@ -2032,16 +2256,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -2058,34 +2282,34 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Weitere Infos
       </h2>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Über das Projekt
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -2099,26 +2323,26 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Nützliche Links
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -2132,26 +2356,26 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Über uns
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -2166,26 +2390,26 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Datenquellen
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -2212,7 +2436,7 @@ Array [
         </div>
       </div>
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         F.A.Q.
       </h2>
@@ -2226,19 +2450,19 @@ Array [
         onClick={[Function]}
       />
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Wie kann ich mitmachen?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2246,19 +2470,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Was kann ich tun, wenn Bäume nicht richtig eingetragen sind?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2266,19 +2490,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Warum sollte ich aktiv werden und Bäume gießen?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2286,19 +2510,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Wie gieße ich richtig?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2306,19 +2530,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             An wen kann ich mich wenden, wenn Pumpen kaputt oder beschädigt sind?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2326,19 +2550,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Wie wird mit technischen Problemen umgegangen?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2346,19 +2570,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Warum lädt die Website nicht oder nur sehr langsam?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2366,19 +2590,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Was tun, wenn ich einen Baum fälschlicherweise gegossen habe?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2386,19 +2610,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Ist das Prinzip auf andere Städte übertragbar?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2406,19 +2630,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Ich habe immer noch eine Frage!
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2426,19 +2650,19 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             I don’t speak any German: What’s going on here?
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             +
@@ -2446,13 +2670,13 @@ Array [
         </div>
       </div>
       <div
-        className="sc-bZSQDF bHpiME"
+        className="sc-bBrOnJ ghZEuN"
       >
         <span>
           Teilen:
         </span>
         <div
-          className="sc-iUuytg fAytJM"
+          className="sc-cOajty iOcAbN"
         >
           <button
             aria-label="facebook"
@@ -2523,11 +2747,11 @@ Array [
         </div>
       </div>
       <div
-        className="sc-iBaPrD hExSaG"
+        className="sc-AzgDb hgQeNQ"
       >
         <img
           alt="GitHub Mark"
-          className="sc-eggNIi kWTjns"
+          className="sc-khAkjo iJLIPT"
           src="/images/icon-github.svg"
         />
         <p
@@ -3214,16 +3438,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -3240,25 +3464,25 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Profil
       </h2>
       <div
-        className="sc-aemoO crUBfh"
+        className="sc-dtwoBo Deuix"
       >
         <div
-          className="sc-dwfUOf bieLLR"
+          className="sc-bTvRPi JzmSn"
         >
           <img
-            className="sc-TmcTc jebECr"
+            className="sc-kIeTtH kWOGMl"
             src="/images/icon-trees.svg"
           />
           <div
-            className="sc-jHVexB isPKdK"
+            className="sc-hOqqkJ jbYLeT"
           >
             Lade Profil...
           </div>
@@ -3266,7 +3490,7 @@ Array [
         </div>
       </div>
       <p
-        className="sc-gsTCUz iiIrBj sc-fWSCIC llMcho"
+        className="sc-gsTCUz iiIrBj sc-eLgOdN eRkbMs"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
@@ -3945,16 +4169,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -3971,37 +4195,37 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Profil
       </h2>
       <span
-        className="sc-eLgOdN iHVZCE"
+        className="sc-jQbIHB jqDmOp"
       >
         Dein Gießfortschritt
       </span>
       <div
-        className="sc-nFpLZ bldavV"
+        className="sc-GqfZa csAaUE"
       >
         <div
-          className="sc-higXBA jcXPpg"
+          className="sc-fWSCIC fGSapi"
         >
           <div
-            className="sc-hHftDr ddCSLS"
+            className="sc-lmoMRL gVOsiP"
           >
             <img
-              className="sc-dmlrTW iHPMlG"
+              className="sc-iJuUWI fIDorH"
               src="/images/icon-trees.svg"
             />
           </div>
           <div
-            className="sc-ehSCib dGZtrO"
+            className="sc-dwfUOf brzRFx"
           >
             <span
-              className="sc-lcujXC gxSE"
+              className="sc-TmcTc kWQhYa"
             >
               0
             </span>
@@ -4017,21 +4241,21 @@ Array [
           </div>
         </div>
         <div
-          className="sc-higXBA jcXPpg"
+          className="sc-fWSCIC fGSapi"
         >
           <div
-            className="sc-hHftDr ddCSLS"
+            className="sc-lmoMRL gVOsiP"
           >
             <img
-              className="sc-dmlrTW iHPMlG"
+              className="sc-iJuUWI fIDorH"
               src="/images/icon-water.svg"
             />
           </div>
           <div
-            className="sc-ehSCib dGZtrO"
+            className="sc-dwfUOf brzRFx"
           >
             <span
-              className="sc-lcujXC gxSE"
+              className="sc-TmcTc kWQhYa"
             >
               0
             </span>
@@ -4048,28 +4272,28 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             <span>
               Adoptierte Bäume
             </span>
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -4083,34 +4307,34 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Dein Account
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
-            className="sc-gGmIRh LHhLW"
+            className="sc-jHVexB idsJbT"
           >
             bob
           </p>
           <p
-            className="sc-gGmIRh LHhLW"
+            className="sc-jHVexB idsJbT"
           >
             bob@example.com
           </p>
@@ -4136,7 +4360,7 @@ Array [
         Konto anlegen / Einloggen
       </div>
       <p
-        className="sc-fKFyDc hpBGMv"
+        className="sc-ezrdKe fxCTcN"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Möchtest du deinen Account löschen? Damit werden alle von dir generierten Wässerungsdaten einem anonymen Benutzer zugeordnet. Dein Benutzer bei unserem Authentifizierungsdienst Auth0.com wird sofort und unwiderruflich gelöscht.",
@@ -4824,16 +5048,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -4850,37 +5074,37 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Profil
       </h2>
       <span
-        className="sc-eLgOdN iHVZCE"
+        className="sc-jQbIHB jqDmOp"
       >
         Dein Gießfortschritt
       </span>
       <div
-        className="sc-nFpLZ bldavV"
+        className="sc-GqfZa csAaUE"
       >
         <div
-          className="sc-higXBA jcXPpg"
+          className="sc-fWSCIC fGSapi"
         >
           <div
-            className="sc-hHftDr ddCSLS"
+            className="sc-lmoMRL gVOsiP"
           >
             <img
-              className="sc-dmlrTW iHPMlG"
+              className="sc-iJuUWI fIDorH"
               src="/images/icon-trees.svg"
             />
           </div>
           <div
-            className="sc-ehSCib dGZtrO"
+            className="sc-dwfUOf brzRFx"
           >
             <span
-              className="sc-lcujXC gxSE"
+              className="sc-TmcTc kWQhYa"
             >
               2
             </span>
@@ -4896,21 +5120,21 @@ Array [
           </div>
         </div>
         <div
-          className="sc-higXBA jcXPpg"
+          className="sc-fWSCIC fGSapi"
         >
           <div
-            className="sc-hHftDr ddCSLS"
+            className="sc-lmoMRL gVOsiP"
           >
             <img
-              className="sc-dmlrTW iHPMlG"
+              className="sc-iJuUWI fIDorH"
               src="/images/icon-water.svg"
             />
           </div>
           <div
-            className="sc-ehSCib dGZtrO"
+            className="sc-dwfUOf brzRFx"
           >
             <span
-              className="sc-lcujXC gxSE"
+              className="sc-TmcTc kWQhYa"
             >
               20
             </span>
@@ -4927,40 +5151,40 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             <span>
               Adoptierte Bäume
             </span>
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <div
-            className="sc-GqfZa cebOe"
+            className="sc-hlTvYk imIYrx"
           >
             <div
-              className="sc-clsHhM izYNEe"
+              className="sc-aemoO fJhjES"
               onClick={[Function]}
               role="button"
               tabIndex={0}
             >
               <span
-                className="sc-fbkhIv"
+                className="sc-jONnTn"
               >
                 Baum-Hasel
               </span>
@@ -4979,34 +5203,34 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Dein Account
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
-            className="sc-gGmIRh LHhLW"
+            className="sc-jHVexB idsJbT"
           >
             bob
           </p>
           <p
-            className="sc-gGmIRh LHhLW"
+            className="sc-jHVexB idsJbT"
           >
             bob@example.com
           </p>
@@ -5032,7 +5256,7 @@ Array [
         Konto anlegen / Einloggen
       </div>
       <p
-        className="sc-fKFyDc hpBGMv"
+        className="sc-ezrdKe fxCTcN"
         dangerouslySetInnerHTML={
           Object {
             "__html": "Möchtest du deinen Account löschen? Damit werden alle von dir generierten Wässerungsdaten einem anonymen Benutzer zugeordnet. Dein Benutzer bei unserem Authentifizierungsdienst Auth0.com wird sofort und unwiderruflich gelöscht.",
@@ -5720,16 +5944,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -5746,18 +5970,18 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Profil
       </h2>
       <div
-        className="sc-hlTvYk jxdXPG"
+        className="sc-jUEnpm qmXEr"
       >
         <p
-          className="sc-fKFyDc hpBGMv"
+          className="sc-ezrdKe fxCTcN"
           dangerouslySetInnerHTML={
             Object {
               "__html": "Du bist momentan nicht eingeloggt. Wenn du das Gießen von Bäumen in deiner Umgebung hier eintragen möchtest, dann registriere dich oder logge dich ein.",
@@ -6412,16 +6636,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -6438,34 +6662,34 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Suche & Filter
       </h2>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Datenansicht
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -6477,22 +6701,22 @@ Array [
             onClick={[Function]}
           />
           <div
-            className="sc-jeGSBP hFVUlZ"
+            className="sc-clsHhM jWRCOx"
           >
             <span
-              className="sc-eJMQSu jvXdJb"
+              className="sc-fbkhIv dCNKUi"
               onClick={[Function]}
             >
               Niederschläge
             </span>
             <span
-              className="sc-eJMQSu lggJlf"
+              className="sc-fbkhIv etVTlW"
               onClick={[Function]}
             >
               Bereits adoptiert
             </span>
             <span
-              className="sc-eJMQSu lggJlf"
+              className="sc-fbkhIv etVTlW"
               onClick={[Function]}
             >
               In den letzten 30 Tagen gegossen
@@ -6501,26 +6725,26 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Baumalter
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <p
             className="sc-gsTCUz iiIrBj"
@@ -6533,10 +6757,10 @@ Array [
           />
           <br />
           <div
-            className="sc-AzgDb lpryqF"
+            className="sc-jeGSBP hNjwNG"
           >
             <span
-              className="sc-hTZhsR hDkAwq"
+              className="sc-nFpLZ gxzVEb"
             >
               0
                - 
@@ -6544,7 +6768,7 @@ Array [
                Jahre
             </span>
             <div
-              className="sc-khAkjo jPJGwK"
+              className="sc-eJMQSu dvFMvb"
             >
               <div
                 className="rc-slider rc-slider-with-marks"
@@ -6735,39 +6959,39 @@ Array [
         </div>
       </div>
       <div
-        className="sc-jNMdTA eyteIo"
+        className="sc-jgHCyG iuOiLs"
       >
         <div
-          className="sc-dOSReg iEeulZ"
+          className="sc-gTgzIj lkXiws"
           onClick={[Function]}
         >
           <div
-            className="sc-cTkwdZ hAnpBT"
+            className="sc-hTZhsR dOSvjF"
           >
             Standortsuche
           </div>
           <span
-            className="sc-cOajty kjwNDU"
+            className="sc-iNqMTl bvuvgJ"
             onClick={[Function]}
           >
             –
           </span>
         </div>
         <div
-          className="sc-bBrOnJ jaYsjs"
+          className="sc-laRPJI eKTkhN"
         >
           <div
-            className="sc-jgHCyG eFqvyx"
+            className="sc-higXBA PJHoA"
           >
             <input
-              className="sc-gTgzIj hgZVNg"
+              className="sc-ehSCib eaStxD"
               onChange={[Function]}
               placeholder="Adresse"
               type="text"
               value=""
             />
             <ul
-              className="sc-laRPJI gvxdoh"
+              className="sc-lcujXC cHAkoW"
             />
           </div>
         </div>
@@ -7400,16 +7624,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -7426,25 +7650,25 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Bauminformation
       </h2>
       <div
-        className="sc-aemoO crUBfh"
+        className="sc-dtwoBo Deuix"
       >
         <div
-          className="sc-dwfUOf bieLLR"
+          className="sc-bTvRPi JzmSn"
         >
           <img
-            className="sc-TmcTc jebECr"
+            className="sc-kIeTtH kWOGMl"
             src="/images/icon-trees.svg"
           />
           <div
-            className="sc-jHVexB isPKdK"
+            className="sc-hOqqkJ jbYLeT"
           >
             Lade Bauminformation...
           </div>
@@ -7452,7 +7676,7 @@ Array [
         </div>
       </div>
       <p
-        className="sc-gsTCUz iiIrBj sc-fWSCIC llMcho"
+        className="sc-gsTCUz iiIrBj sc-eLgOdN eRkbMs"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
@@ -8088,16 +8312,16 @@ Array [
     </button>
   </footer>,
   <div
-    className="sc-xyEjG kQubfv"
+    className="sc-eFubAy gGZCPy"
   >
     <a
-      className="sc-kYrkKh mQMrD"
+      className="sc-jXktwP igeGQR"
       href="/"
       onClick={[Function]}
     >
       <button
         aria-label="Leiste schließen"
-        className="sc-cxFLnm kdoGKp"
+        className="sc-iktFzd kagoRh"
         onClick={[Function]}
         title="Leiste schließen"
       >
@@ -8114,25 +8338,25 @@ Array [
       </button>
     </a>
     <div
-      className="sc-dWdcrH bpviTh"
+      className="sc-fmlJLJ hDwrzQ"
     >
       <h2
-        className="sc-jcVebW kkYLBV"
+        className="sc-dOSReg LQxMu"
       >
         Bauminformation
       </h2>
       <div
-        className="sc-aemoO crUBfh"
+        className="sc-dtwoBo Deuix"
       >
         <div
-          className="sc-dwfUOf bieLLR"
+          className="sc-bTvRPi JzmSn"
         >
           <img
-            className="sc-TmcTc jebECr"
+            className="sc-kIeTtH kWOGMl"
             src="/images/icon-trees.svg"
           />
           <div
-            className="sc-jHVexB isPKdK"
+            className="sc-hOqqkJ jbYLeT"
           >
             Lade Bauminformation...
           </div>
@@ -8140,7 +8364,7 @@ Array [
         </div>
       </div>
       <p
-        className="sc-gsTCUz iiIrBj sc-fWSCIC llMcho"
+        className="sc-gsTCUz iiIrBj sc-eLgOdN eRkbMs"
         dangerouslySetInnerHTML={
           Object {
             "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
@@ -8162,19 +8386,19 @@ exports[`Storyshots StackedBarChart Bar Chart 1`] = `
   }
 >
   <div
-    className="sc-eGCarw eMtaVZ"
+    className="sc-dtTInj bmJEHF"
     id="barchart"
   >
     <div
-      className="sc-bsipQr gabrJa"
+      className="sc-ikPAkQ coFneo"
       id="barchart-tooltip"
     >
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#8B77F7",
@@ -8187,11 +8411,11 @@ exports[`Storyshots StackedBarChart Bar Chart 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#75ADE8",
@@ -8204,10 +8428,10 @@ exports[`Storyshots StackedBarChart Bar Chart 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <span
-          className="sc-euMpXR bbHNB"
+          className="sc-biBrSq HZGBn"
         >
           ∑
         </span>
@@ -8218,11 +8442,11 @@ exports[`Storyshots StackedBarChart Bar Chart 1`] = `
     </div>
   </div>
   <div
-    className="sc-ctaXAZ iKRVLG"
+    className="sc-dkIXFM hNsFmu"
   >
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#8B77F7",
@@ -8235,7 +8459,7 @@ exports[`Storyshots StackedBarChart Bar Chart 1`] = `
     </div>
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#75ADE8",
@@ -8259,19 +8483,19 @@ exports[`Storyshots StackedBarChart Bar Chart February 1`] = `
   }
 >
   <div
-    className="sc-eGCarw eMtaVZ"
+    className="sc-dtTInj bmJEHF"
     id="barchart"
   >
     <div
-      className="sc-bsipQr gabrJa"
+      className="sc-ikPAkQ coFneo"
       id="barchart-tooltip"
     >
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#8B77F7",
@@ -8284,11 +8508,11 @@ exports[`Storyshots StackedBarChart Bar Chart February 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#75ADE8",
@@ -8301,10 +8525,10 @@ exports[`Storyshots StackedBarChart Bar Chart February 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <span
-          className="sc-euMpXR bbHNB"
+          className="sc-biBrSq HZGBn"
         >
           ∑
         </span>
@@ -8315,11 +8539,11 @@ exports[`Storyshots StackedBarChart Bar Chart February 1`] = `
     </div>
   </div>
   <div
-    className="sc-ctaXAZ iKRVLG"
+    className="sc-dkIXFM hNsFmu"
   >
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#8B77F7",
@@ -8332,7 +8556,7 @@ exports[`Storyshots StackedBarChart Bar Chart February 1`] = `
     </div>
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#75ADE8",
@@ -8356,19 +8580,19 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
   }
 >
   <div
-    className="sc-eGCarw eMtaVZ"
+    className="sc-dtTInj bmJEHF"
     id="barchart"
   >
     <div
-      className="sc-bsipQr gabrJa"
+      className="sc-ikPAkQ coFneo"
       id="barchart-tooltip"
     >
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#8B77F7",
@@ -8381,11 +8605,11 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <strong>
           <div
-            className="sc-dFJsGO dICqkK"
+            className="sc-XhUPp vTgFU"
             style={
               Object {
                 "backgroundColor": "#75ADE8",
@@ -8398,10 +8622,10 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
         />
       </span>
       <span
-        className="sc-gInsOo ljihCS"
+        className="sc-tYoTV fVdDbB"
       >
         <span
-          className="sc-euMpXR bbHNB"
+          className="sc-biBrSq HZGBn"
         >
           ∑
         </span>
@@ -8412,11 +8636,11 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
     </div>
   </div>
   <div
-    className="sc-ctaXAZ iKRVLG"
+    className="sc-dkIXFM hNsFmu"
   >
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#8B77F7",
@@ -8429,7 +8653,7 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
     </div>
     <div>
       <div
-        className="sc-dFJsGO dICqkK"
+        className="sc-XhUPp vTgFU"
         style={
           Object {
             "backgroundColor": "#75ADE8",
@@ -8440,230 +8664,6 @@ exports[`Storyshots StackedBarChart Bar Chart New Year 1`] = `
          Regen
       </div>
     </div>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Tooltip Default 1`] = `
-<div
-  className="sc-jGVbCA gAKAyi"
->
-  <header
-    className="sc-bQdQlF liHyzl"
-  >
-    <h3
-      className="sc-fXoxut hmiKgb"
-    >
-      This is a title
-    </h3>
-  </header>
-  <div
-    className="sc-eFubAy cyCewY"
-  >
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Tooltip With Subtitle 1`] = `
-<div
-  className="sc-jGVbCA gAKAyi"
->
-  <header
-    className="sc-bQdQlF liHyzl"
-  >
-    <h3
-      className="sc-fXoxut hmiKgb"
-    >
-      This is a title
-    </h3>
-    <h4
-      className="sc-Fyfyc kYFDqc"
-    >
-      Subtitle
-    </h4>
-  </header>
-  <div
-    className="sc-eFubAy cyCewY"
-  >
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Tooltip With Subtitle And Children 1`] = `
-<div
-  className="sc-jGVbCA gAKAyi"
->
-  <header
-    className="sc-bQdQlF liHyzl"
-  >
-    <h3
-      className="sc-fXoxut hmiKgb"
-    >
-      This is a title
-    </h3>
-    <h4
-      className="sc-Fyfyc kYFDqc"
-    >
-      Subtitle
-    </h4>
-    <div
-      className="sc-jXktwP fnxDQO"
-    >
-      <span>
-        Here be React children.
-      </span>
-    </div>
-  </header>
-  <div
-    className="sc-eFubAy cyCewY"
-  >
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
-</div>
-`;
-
-exports[`Storyshots Tooltip Without Subtitle And With Children 1`] = `
-<div
-  className="sc-jGVbCA gAKAyi"
->
-  <header
-    className="sc-bQdQlF liHyzl"
-  >
-    <h3
-      className="sc-fXoxut hmiKgb"
-    >
-      This is a title
-    </h3>
-    <div
-      className="sc-jXktwP fnxDQO"
-    >
-      <span>
-        Here be React children.
-      </span>
-    </div>
-  </header>
-  <div
-    className="sc-eFubAy cyCewY"
-  >
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-fmlJLJ eQaNGi"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
   </div>
 </div>
 `;

--- a/src/__snapshots__/storybook.test.ts.snap
+++ b/src/__snapshots__/storybook.test.ts.snap
@@ -473,7 +473,7 @@ Array [
 
 exports[`Storyshots DataTable Default 1`] = `
 <div
-  className="sc-eCssSg ftSzBv"
+  className="sc-eCssSg fZXGpi"
 >
   <header
     className="sc-jSgupP iUjCLu"
@@ -484,46 +484,48 @@ exports[`Storyshots DataTable Default 1`] = `
       This is a title
     </h3>
   </header>
-  <div
-    className="sc-pFZIQ ksLDOc"
+  <table
+    className="sc-pFZIQ dHBYJo"
   >
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
+    <tbody>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Status
+        </th>
+        <td>
+          Unknown
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Last update
+        </th>
+        <td>
+          Yesterday
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Type
+        </th>
+        <td>
+          Random type
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
 exports[`Storyshots DataTable With Subtitle 1`] = `
 <div
-  className="sc-eCssSg ftSzBv"
+  className="sc-eCssSg fZXGpi"
 >
   <header
     className="sc-jSgupP iUjCLu"
@@ -539,46 +541,48 @@ exports[`Storyshots DataTable With Subtitle 1`] = `
       Subtitle
     </h4>
   </header>
-  <div
-    className="sc-pFZIQ ksLDOc"
+  <table
+    className="sc-pFZIQ dHBYJo"
   >
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
+    <tbody>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Status
+        </th>
+        <td>
+          Unknown
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Last update
+        </th>
+        <td>
+          Yesterday
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Type
+        </th>
+        <td>
+          Random type
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
 exports[`Storyshots DataTable With Subtitle And Children 1`] = `
 <div
-  className="sc-eCssSg ftSzBv"
+  className="sc-eCssSg fZXGpi"
 >
   <header
     className="sc-jSgupP iUjCLu"
@@ -601,46 +605,48 @@ exports[`Storyshots DataTable With Subtitle And Children 1`] = `
       </span>
     </div>
   </header>
-  <div
-    className="sc-pFZIQ ksLDOc"
+  <table
+    className="sc-pFZIQ dHBYJo"
   >
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
+    <tbody>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Status
+        </th>
+        <td>
+          Unknown
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Last update
+        </th>
+        <td>
+          Yesterday
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Type
+        </th>
+        <td>
+          Random type
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 
 exports[`Storyshots DataTable Without Subtitle And With Children 1`] = `
 <div
-  className="sc-eCssSg ftSzBv"
+  className="sc-eCssSg fZXGpi"
 >
   <header
     className="sc-jSgupP iUjCLu"
@@ -658,40 +664,42 @@ exports[`Storyshots DataTable Without Subtitle And With Children 1`] = `
       </span>
     </div>
   </header>
-  <div
-    className="sc-pFZIQ ksLDOc"
+  <table
+    className="sc-pFZIQ dHBYJo"
   >
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Status
-      </th>
-      <td>
-        Unknown
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Last update
-      </th>
-      <td>
-        Yesterday
-      </td>
-    </tr>
-    <tr
-      className="sc-jrAGrp hBErSp"
-    >
-      <th>
-        Type
-      </th>
-      <td>
-        Random type
-      </td>
-    </tr>
-  </div>
+    <tbody>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Status
+        </th>
+        <td>
+          Unknown
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Last update
+        </th>
+        <td>
+          Yesterday
+        </td>
+      </tr>
+      <tr
+        className="sc-jrAGrp hBErSp"
+      >
+        <th>
+          Type
+        </th>
+        <td>
+          Random type
+        </td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 `;
 

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-import { Tooltip as TooltipComp, TooltipProps } from '.';
+import { DataTable, DataTableType } from '.';
 import { Story } from '@storybook/react/types-6-0';
 
 export default {
-  title: 'Tooltip',
-  component: TooltipComp,
+  title: 'DataTable',
+  component: DataTable,
 };
 
-const Template: Story<TooltipProps> = args => (
-  <TooltipComp {...args}>{args.children}</TooltipComp>
+const Template: Story<DataTableType> = args => (
+  <DataTable {...args}>{args.children}</DataTable>
 );
 
 export const Default = Template.bind({});

--- a/src/components/DataTable/DataTable.test.tsx
+++ b/src/components/DataTable/DataTable.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Tooltip, TooltipProps } from '.';
+import { DataTable, DataTableType } from '.';
 
-const exampleInput: TooltipProps = {
+const exampleInput: DataTableType = {
   title: 'title',
   subtitle: 'subtitle',
   items: {
@@ -11,9 +11,9 @@ const exampleInput: TooltipProps = {
   },
 };
 
-describe('component Tooltip', () => {
+describe('component DataTable', () => {
   test('should render the provided inputs', () => {
-    render(<Tooltip {...exampleInput}>hello gepetto</Tooltip>);
+    render(<DataTable {...exampleInput}>hello gepetto</DataTable>);
     const titleElement = screen.getByRole('heading', {
       level: 3,
       name: 'title',

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -41,11 +41,10 @@ const StyledChildrenWrapper = styled.div`
   }
 `;
 
-const StyledTable = styled.div`
+const StyledTable = styled.table`
   font-size: ${props => props.theme.fontSizeL};
   font-family: ${props => props.theme.fontFamily};
   width: 100%;
-  display: block;
 `;
 
 const StyledTableRow = styled.tr`
@@ -77,14 +76,16 @@ export const DataTable: React.FC<DataTableType> = ({
         {children && <StyledChildrenWrapper>{children}</StyledChildrenWrapper>}
       </StyledHeader>
       <StyledTable>
-        {Object.entries(items).map(([key, value]) => {
-          return (
-            <StyledTableRow key={`row-${key}`}>
-              <th>{key}</th>
-              <td>{value}</td>
-            </StyledTableRow>
-          );
-        })}
+        <tbody>
+          {Object.entries(items).map(([key, value]) => {
+            return (
+              <StyledTableRow key={`row-${key}`}>
+                <th>{key}</th>
+                <td>{value}</td>
+              </StyledTableRow>
+            );
+          })}
+        </tbody>
       </StyledTable>
     </StyledWrapper>
   );

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
-interface TooltipValuesType {
+interface TableItemsType {
   [key: string]: string;
 }
-export interface TooltipProps {
+export interface DataTableType {
   title: string;
   subtitle?: string;
-  items: TooltipValuesType;
+  items: TableItemsType;
   children?: ReactNode;
 }
 
@@ -65,7 +65,7 @@ const StyledTableRow = styled.tr`
   }
 `;
 
-export const Tooltip: React.FC<TooltipProps> = ({
+export const DataTable: React.FC<DataTableType> = ({
   title,
   subtitle,
   items,

--- a/src/components/DataTable/index.tsx
+++ b/src/components/DataTable/index.tsx
@@ -1,21 +1,19 @@
-import React, { ReactNode } from 'react';
+import React, { HTMLProps } from 'react';
 import styled from 'styled-components';
 
 interface TableItemsType {
   [key: string]: string;
 }
-export interface DataTableType {
+export interface DataTableType extends HTMLProps<HTMLDivElement> {
   title: string;
   subtitle?: string;
   items: TableItemsType;
-  children?: ReactNode;
 }
 
 const StyledWrapper = styled.div`
-  max-width: 340px;
+  width: 260px;
   display: block;
-  /* box-shadow: rgba(51, 51, 102, 0.5) 2px 2px 2px; */
-  padding ${({ theme }) => theme.spacingM};
+  padding ${({ theme }) => theme.spacingS};
   background-color: ${({ theme }) => theme.colorWhite};
 `;
 

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,37 +1,56 @@
-import React, { ReactNode } from 'react';
-import { Tooltip as TooltipComp } from '.';
+import React from 'react';
+import { Tooltip as TooltipComp, TooltipProps } from '.';
 import { Story } from '@storybook/react/types-6-0';
-import WaterDrops from '../WaterDrops';
 
 export default {
   title: 'Tooltip',
   component: TooltipComp,
 };
 
-const Template: Story<{
-  children: ReactNode;
-  x: number;
-  y: number;
-}> = ({ children, x, y }) => (
-  <TooltipComp x={x} y={y}>
-    {children}
-  </TooltipComp>
+const Template: Story<TooltipProps> = args => (
+  <TooltipComp {...args}>{args.children}</TooltipComp>
 );
 
-export const WithTextString = Template.bind({});
-WithTextString.args = {
-  x: 100,
-  y: 100,
-  children: 'This is a tooltip',
+export const Default = Template.bind({});
+Default.args = {
+  title: 'This is a title',
+  items: {
+    Status: 'Unknown',
+    'Last update': 'Yesterday',
+    Type: 'Random type',
+  },
 };
 
-export const WithReactChildren = Template.bind({});
-WithReactChildren.args = {
-  x: 200,
-  y: 150,
-  children: (
-    <>
-      <b>Bold and sweaty</b> <WaterDrops dropsAmount={2} />
-    </>
-  ),
+export const WithSubtitle = Template.bind({});
+WithSubtitle.args = {
+  title: 'This is a title',
+  subtitle: 'Subtitle',
+  items: {
+    Status: 'Unknown',
+    'Last update': 'Yesterday',
+    Type: 'Random type',
+  },
+};
+
+export const WithoutSubtitleAndWithChildren = Template.bind({});
+WithoutSubtitleAndWithChildren.args = {
+  title: 'This is a title',
+  items: {
+    Status: 'Unknown',
+    'Last update': 'Yesterday',
+    Type: 'Random type',
+  },
+  children: <span>Here be React children.</span>,
+};
+
+export const WithSubtitleAndChildren = Template.bind({});
+WithSubtitleAndChildren.args = {
+  title: 'This is a title',
+  subtitle: 'Subtitle',
+  items: {
+    Status: 'Unknown',
+    'Last update': 'Yesterday',
+    Type: 'Random type',
+  },
+  children: <span>Here be React children.</span>,
 };

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -1,27 +1,34 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Tooltip } from '.';
+import { Tooltip, TooltipProps } from '.';
+
+const exampleInput: TooltipProps = {
+  title: 'title',
+  subtitle: 'subtitle',
+  items: {
+    a: 'yo',
+    b: 'yoyo',
+  },
+};
 
 describe('component Tooltip', () => {
-  test('should render the provided message', () => {
-    render(
-      <Tooltip x={0} y={0}>
-        hello gepetto
-      </Tooltip>
-    );
-    const message = screen.getByText('hello gepetto');
-    expect(message).toBeInTheDocument();
-  });
-  test('should render the hover object based on pointer', () => {
-    render(
-      <Tooltip x={500} y={300}>
-        hello gepetto
-      </Tooltip>
-    );
-    const bubble = document.querySelector('.tooltip');
-    if (!bubble) throw new Error('Could not find bubble');
-    const computedStyle = getComputedStyle(bubble);
-    expect(computedStyle.left).toBe('497px');
-    expect(computedStyle.top).toBe('255px');
+  test('should render the provided inputs', () => {
+    render(<Tooltip {...exampleInput}>hello gepetto</Tooltip>);
+    const titleElement = screen.getByRole('heading', {
+      level: 3,
+      name: 'title',
+    });
+    expect(titleElement).toBeInTheDocument();
+    const subtitleElement = screen.getByRole('heading', {
+      level: 4,
+      name: 'subtitle',
+    });
+    expect(subtitleElement).toBeInTheDocument();
+    const tableHeadElements = screen.getAllByRole('columnheader');
+    tableHeadElements.forEach(el => expect(el).toBeInTheDocument());
+    const tableDataElements = screen.getAllByRole('cell', { name: /yo/g });
+    tableDataElements.forEach(el => expect(el).toBeInTheDocument());
+    const childrenText = screen.getByText('hello gepetto');
+    expect(childrenText).toBeInTheDocument();
   });
 });

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -1,79 +1,93 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
-interface TooltipProps {
-  x: number;
-  y: number;
+interface TooltipValuesType {
+  [key: string]: string;
 }
-interface StyledProps {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+export interface TooltipProps {
+  title: string;
+  subtitle?: string;
+  items: TooltipValuesType;
+  children?: ReactNode;
 }
 
-const StyledSpan = styled.span`
-  padding: 1rem 1rem 0.2rem 1rem;
-  margin: 2rem auto;
-  color: ${props => props.theme.colorTextLight};
+const StyledWrapper = styled.div`
+  max-width: 340px;
+  display: block;
+  /* box-shadow: rgba(51, 51, 102, 0.5) 2px 2px 2px; */
+  padding ${({ theme }) => theme.spacingM};
+  background-color: ${({ theme }) => theme.colorWhite};
 `;
-const Bubble = styled.div<StyledProps>`
-  height: 30px;
-  line-height: 30px;
-  font-size: ${props => props.theme.fontSizeL};
-  box-sizing: border-box;
-  box-shadow: rgba(51, 51, 102, 0.5) 2px 2px 2px;
-  font-family: ${props => props.theme.fontFamily};
-  position: absolute;
-  z-index: 10;
-  pointer-events: none;
-  display: inline-block;
-  text-align: center;
-  vertical-align: middle;
-  left: ${props => props.x - props.width / 2 - 3}px;
-  top: ${props => props.y - 45}px;
-  background-color: #ffffff;
-  margin: 0 auto;
-  &::after {
-    transform: rotate(45deg);
-    border-width: 7px;
-    border-style: solid;
-    border-color: transparent #fff #fff transparent;
-    content: '';
-    position: absolute;
-    bottom: -6px;
-    left: 48%;
-    box-shadow: rgba(51, 51, 102, 0.5) 2px 2px 2px;
+
+const StyledHeader = styled.header`
+  padding-bottom: ${({ theme }) => theme.spacingM};
+  border-bottom: 1px solid ${({ theme }) => theme.colorGreyLight};
+`;
+
+const StyledTitle = styled.h3`
+  font-size: ${props => props.theme.fontSizeXl};
+  color: ${({ theme }) => theme.colorTextDark};
+  margin: 0;
+`;
+
+const StyledSubtitle = styled.h4`
+  font-size: ${props => props.theme.fontSizeLl};
+  font-weight: normal;
+  color: ${({ theme }) => theme.colorTextLight};
+  margin: 2px 0 0;
+`;
+
+const StyledChildrenWrapper = styled.div`
+  &:not(:empty) {
+    margin: ${({ theme }) => theme.spacingS} 0 0;
   }
 `;
 
-export const Tooltip: React.FC<TooltipProps> = ({ children, x, y }) => {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const [width, setWidth] = useState(0);
-  const [height, setHeight] = useState(0);
+const StyledTable = styled.div`
+  font-size: ${props => props.theme.fontSizeL};
+  font-family: ${props => props.theme.fontFamily};
+  width: 100%;
+  display: block;
+`;
 
-  useEffect(() => {
-    if (!ref) return;
-    const w = ref.current ? ref.current?.offsetWidth : 0;
-    const h = ref.current ? ref.current?.offsetHeight : 0;
-    setWidth(w);
-    setHeight(h);
-  }, [ref]);
+const StyledTableRow = styled.tr`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid ${({ theme }) => theme.colorGreyLight};
+  color: ${({ theme }) => theme.colorTextDark};
+  > th {
+    font-weight: bold;
+  }
+  > td {
+    font-weight: normal;
+  }
+`;
 
+export const Tooltip: React.FC<TooltipProps> = ({
+  title,
+  subtitle,
+  items,
+  children,
+}) => {
   return (
-    <>
-      <div>
-        <Bubble
-          className='tooltip'
-          ref={ref}
-          x={x}
-          y={y}
-          width={width}
-          height={height}
-        >
-          <StyledSpan>{children}</StyledSpan>
-        </Bubble>
-      </div>
-    </>
+    <StyledWrapper>
+      <StyledHeader>
+        <StyledTitle>{title}</StyledTitle>
+        {subtitle && <StyledSubtitle>{subtitle}</StyledSubtitle>}
+        {children && <StyledChildrenWrapper>{children}</StyledChildrenWrapper>}
+      </StyledHeader>
+      <StyledTable>
+        {Object.entries(items).map(([key, value]) => {
+          return (
+            <StyledTableRow key={`row-${key}`}>
+              <th>{key}</th>
+              <td>{value}</td>
+            </StyledTableRow>
+          );
+        })}
+      </StyledTable>
+    </StyledWrapper>
   );
 };

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -10,7 +10,7 @@ import {
   FlyToInterpolator,
   Popup,
 } from 'react-map-gl';
-import DeckGL, { GeoJsonLayer } from 'deck.gl';
+import DeckGL, { GeoJsonLayer, LayerInputHandler } from 'deck.gl';
 import { easeCubic as d3EaseCubic, ExtendedFeatureCollection } from 'd3';
 import { interpolateColor, hexToRgb } from '../../utils/colorUtil';
 import { DataTable } from '../DataTable';
@@ -282,20 +282,22 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         pickable: true,
         lineWidthScale: 3,
         lineWidthMinPixels: 1.5,
-        onHover: (info: {
-          object?: {
-            properties: {
-              'addr:full': string;
-              check_date: string;
-              id: number;
-              image: string;
-              'pump:status': string;
-              'pump:style': string;
+        onHover: (
+          info: LayerInputHandler<{
+            object?: {
+              properties: {
+                'addr:full': string;
+                check_date: string;
+                id: number;
+                image: string;
+                'pump:status': string;
+                'pump:style': string;
+              };
+              geometry: { type: string; coordinates: [number, number] };
             };
-            geometry: { type: string; coordinates: [number, number] };
-          };
-          [key: string]: unknown;
-        }) => {
+            [key: string]: unknown;
+          }>
+        ) => {
           if (info.object === undefined) {
             this.setState({ hoveredPump: null });
           } else {

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -280,10 +280,20 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         pickable: true,
         lineWidthScale: 3,
         lineWidthMinPixels: 1.5,
-        onHover: (info: any) => {
-          if (!info.object) {
-            this.setState({ hoveredPump: null });
-          } else {
+        onHover: (info: {
+          object?: {
+            geometry: { coordinates: number[] };
+            properties?:
+              | {
+                  'pump:status'?: string;
+                  'addr:full'?: string;
+                  'pump:style'?: string;
+                  check_date?: string;
+                }
+              | undefined;
+          };
+        }) => {
+          if (info && info.object && info.object.properties) {
             this.setState({
               hoveredPump: {
                 address: info.object.properties['addr:full'] || '',
@@ -294,6 +304,8 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
                 longitude: info.object.geometry.coordinates[0] || undefined,
               },
             });
+          } else {
+            this.setState({ hoveredPump: null });
           }
         },
       }),

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -81,8 +81,6 @@ interface PumpPropertiesType {
 
 interface DeckGLStateType {
   hoveredPump: PumpPropertiesType | null;
-  hoverObjectPointer: [number, number];
-  hoverObjectMessage: string;
   cursor: 'grab' | 'pointer';
   geoLocationAvailable: boolean;
   isTreeMapLoading: boolean;
@@ -95,8 +93,6 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
 
     this.state = {
       hoveredPump: null,
-      hoverObjectPointer: [0, 0],
-      hoverObjectMessage: '', // TODO: remove leftovers
       cursor: 'grab',
       geoLocationAvailable: false,
       isTreeMapLoading: true,

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -282,16 +282,23 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         pickable: true,
         lineWidthScale: 3,
         lineWidthMinPixels: 1.5,
-        onHover: info => {
+        onHover: (info: {
+          object:
+            | {
+                properties: { [x: string]: any };
+                geometry: { type: string; coordinates: [number, number] };
+              }
+            | undefined;
+        }) => {
           if (info.object === undefined) {
             this.setState({ hoveredPump: null });
           } else {
             this.setState({
               hoveredPump: {
-                address: info.object.properties['addr:full'],
-                check_date: info.object.properties['check_date'],
-                status: info.object.properties['pump:status'],
-                style: info.object.properties['pump:style'],
+                address: info.object.properties['addr:full'] || '',
+                check_date: info.object.properties['check_date'] || '',
+                status: info.object.properties['pump:status'] || '',
+                style: info.object.properties['pump:style'] || '',
                 latitude: info.object.geometry.coordinates[1],
                 longitude: info.object.geometry.coordinates[0],
               },

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -283,12 +283,18 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         lineWidthScale: 3,
         lineWidthMinPixels: 1.5,
         onHover: (info: {
-          object:
-            | {
-                properties: { [x: string]: any };
-                geometry: { type: string; coordinates: [number, number] };
-              }
-            | undefined;
+          object?: {
+            properties: {
+              'addr:full': string;
+              check_date: string;
+              id: number;
+              image: string;
+              'pump:status': string;
+              'pump:style': string;
+            };
+            geometry: { type: string; coordinates: [number, number] };
+          };
+          [key: string]: unknown;
         }) => {
           if (info.object === undefined) {
             this.setState({ hoveredPump: null });


### PR DESCRIPTION
This PR updates the tooltip for the pumps. It

- adds a `DataTable` component that can be used for the new tooltip contents (and other things)
- uses `react-map-gl`s own `Popup` for handling user interaction and edge cases such as a tooltip close to the screen edge
- inserts the pump data into the `DataTable` into the `Popup`

![Screenshot 2021-05-06 at 13 37 09](https://user-images.githubusercontent.com/15640196/117292203-34c79f80-ae70-11eb-88ab-a9db7520b410.png)

---

Note: This PR does not handle tooltips for mobile. They are currently already disabled explicitly. The reason for this should be figured out separately.

Note 2: TypeScript here was hard to handle. ~I had to use an `any` because I couldn't trace back where a type mismatch on the `onHover` originated. Pointers welcome!~

---

Tested on latest macOS and Windows in latest Chrome, Firefox, Edge, Safari (only macOS).

Closes #239 