### PR TITLE
fix(MapControls): Fix hidden map controls

### DIFF
--- a/src/assets/MapboxStyleOverrides.ts
+++ b/src/assets/MapboxStyleOverrides.ts
@@ -33,4 +33,12 @@ export const MapboxStyleOverrides = css`
       background: white !important;
     }
   }
+
+  #view-default-view > div {
+    z-index: unset !important;
+  }
+
+  #deckgl-overlay {
+    z-index: 1;
+  }
 `;

--- a/src/components/Nav/index.tsx
+++ b/src/components/Nav/index.tsx
@@ -5,6 +5,7 @@ import InfoIcon from '@material-ui/icons/InfoOutlined';
 import AccountCircle from '@material-ui/icons/AccountCircleOutlined';
 import SearchIcon from '@material-ui/icons/Search';
 import SquareButton from '../SquareButton';
+import { useActions } from '../../state/unistore-hooks';
 
 interface StyledProps {
   active?: boolean;
@@ -48,6 +49,7 @@ const navConfig = [
 const Nav: FC<{
   isNavOpened: boolean;
 }> = ({ isNavOpened }) => {
+  const { openNav } = useActions();
   const { pathname } = useLocation();
   const history = useHistory();
 
@@ -57,7 +59,10 @@ const Nav: FC<{
         <NavItem
           exact
           to={{ pathname: item.path, search: '' }}
-          onClick={() => history.push('/')}
+          onClick={() => {
+            history.push('/');
+            openNav();
+          }}
           title={item.title}
           key={item.path}
         >

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -25,7 +25,7 @@ interface StyledProps {
   isNavOpen?: boolean;
 }
 const ControlWrapper = styled.div<StyledProps>`
-  position: absolute;
+  position: fixed;
   bottom: 12px;
   left: 12px;
   z-index: 2;
@@ -33,7 +33,11 @@ const ControlWrapper = styled.div<StyledProps>`
 
   @media screen and (min-width: ${p => p.theme.screens.tablet}) {
     transform: ${props =>
-      props.isNavOpen ? 'translate3d(350px, 0, 0)' : 'none'};
+      props.isNavOpen ? 'translate3d(350px, 0, 0)' : 'translate3d(0, 0, 0)'};
+  }
+
+  & > div {
+    position: static !important;
   }
 `;
 

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -643,20 +643,20 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
               </ControlWrapper>
             )}
           </StaticMap>
-          {hoveredPump && hoveredPump.x && hoveredPump.y && (
-            <MapTooltip
-              x={hoveredPump.x}
-              y={hoveredPump.y}
-              title='Öffentliche Straßenpumpe'
-              subtitle={hoveredPump.address}
-              infos={{
-                Status: hoveredPump.status,
-                'Letzter Check': hoveredPump.check_date,
-                Pumpenstil: hoveredPump.style,
-              }}
-            />
-          )}
         </DeckGL>
+        {hoveredPump && hoveredPump.x && hoveredPump.y && (
+          <MapTooltip
+            x={hoveredPump.x}
+            y={hoveredPump.y}
+            title='Öffentliche Straßenpumpe'
+            subtitle={hoveredPump.address}
+            infos={{
+              Status: hoveredPump.status,
+              'Letzter Check': hoveredPump.check_date,
+              Pumpenstil: hoveredPump.style,
+            }}
+          />
+        )}
       </>
     );
   }

--- a/src/components/TreesMap/MapTooltip.tsx
+++ b/src/components/TreesMap/MapTooltip.tsx
@@ -7,7 +7,7 @@ export const TOOLTIP_WIDTH = 260;
 const StyledTooltipWrapper = styled.div`
   width: ${TOOLTIP_WIDTH}px;
   position: absolute;
-  z-index: 1;
+  z-index: 3;
   pointer-events: none;
   box-shadow: ${({ theme }) => theme.boxShadow};
   transform: translate(-50%, 10px);

--- a/src/state/Actions.tsx
+++ b/src/state/Actions.tsx
@@ -25,6 +25,10 @@ const closeOverlay = (): { overlay: StoreProps['overlay'] } => ({
   overlay: false,
 });
 
+const openNav = (): { isNavOpen: StoreProps['isNavOpen'] } => ({
+  isNavOpen: true,
+});
+
 const closeNav = (): { isNavOpen: StoreProps['isNavOpen'] } => ({
   isNavOpen: false,
 });
@@ -34,6 +38,7 @@ const allActions = {
   setAgeRange,
   openOverlay,
   closeOverlay,
+  openNav,
   closeNav,
   setVisibleMapLayer,
   setMapViewFilter,

--- a/src/state/Store.tsx
+++ b/src/state/Store.tsx
@@ -3,7 +3,7 @@ import { StoreProps } from '../common/interfaces';
 
 const initialState: StoreProps = {
   mapViewFilter: 'rain',
-  isNavOpen: false,
+  isNavOpen: true,
   visibleMapLayer: 'trees',
   ageRange: [0, 320],
   overlay: true,


### PR DESCRIPTION
This PR displays the map controls back into the view. It seems like an update of react-map-gl has messed up the order of display of element. This bug is older and has gone unnoticed for a while. The sidebar, state, for instance, wasn't opening anymore when a button was clicked.