### PR TITLE
refactor: trees data URLS as env variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,14 @@
 # ATTENTION: No URL should have a trailing slash
 
-# Mapbox Token
+# Mapbox Credentials
 MAPBOX_API_KEY=pk.123.xyz
+
+# Trees data source (for desktop)
+AWS_TREES_URL={AWS_LINK_TO_TREES_AS_CSV}
+
+# Trees data source (for mobile)
+MAPBOX_TREES_TILESET_URL=mapbox://{username}.{tilesetId}
+MAPBOX_TREES_TILESET_LAYER={layer-name-within-tileset}
 
 # Auth0
 AUTH0_DOMAIN=myauthzeropath.eu.auth0.com

--- a/create-env.js
+++ b/create-env.js
@@ -3,6 +3,9 @@ const fs = require('fs');
 const envVars = `
 # these are only generated on netlify deploy
 MAPBOX_API_KEY=${process.env.MAPBOX_API_KEY}\n
+MAPBOX_TREES_TILESET_URL=${process.env.MAPBOX_TREES_TILESET_URL}\n
+MAPBOX_TREES_TILESET_LAYER=${process.env.MAPBOX_TREES_TILESET_LAYER}\n
+AWS_TREES_URL=${process.env.AWS_TREES_URL}\n
 AUTH0_DOMAIN=${process.env.AUTH0_DOMAIN}\n
 AUTH0_CLIENT_ID=${process.env.AUTH0_CLIENT_ID}\n
 AUTH0_AUDIENCE=${process.env.AUTH0_AUDIENCE}\n

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -429,7 +429,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
 
       map.addSource('trees', {
         type: 'vector',
-        url: 'mapbox://technologiestiftung.trees_s3',
+        url: process.env.MAPBOX_TREES_TILESET_URL,
         minzoom: 11,
         maxzoom: 20,
       });
@@ -438,7 +438,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
         id: 'trees',
         type: 'circle',
         source: 'trees',
-        'source-layer': 'original',
+        'source-layer': process.env.MAPBOX_TREES_TILESET_LAYER,
         // TODO: Below we add the style for the trees on mobile. The color updates should be inserted or replicated here.
         paint: {
           'circle-radius': {

--- a/src/utils/requests/loadTreesGeoJson.ts
+++ b/src/utils/requests/loadTreesGeoJson.ts
@@ -40,8 +40,7 @@ function createGeojson(trees: Tree[]): ExtendedFeatureCollection {
 }
 
 export const loadTreesGeoJson = async (): Promise<ExtendedFeatureCollection> => {
-  const dataUrl =
-    'https://tsb-trees.s3.eu-central-1.amazonaws.com/trees.csv.gz';
+  const dataUrl = process.env.AWS_TREES_URL as string;
 
   const data = await d3Dsv(',', dataUrl, { cache: 'force-cache' });
   const geojson = createGeojson((data as unknown) as Tree[]);


### PR DESCRIPTION
This PR moves the URLs for the trees data (mobile and desktop) into environment variables.

```
# Trees data source (for desktop)
AWS_TREES_URL={AWS_LINK_TO_TREES_AS_CSV}

# Trees data source (for mobile)
MAPBOX_TREES_TILESET_URL=mapbox://{username}.{tilesetId}
MAPBOX_TREES_TILESET_LAYER={layer-name-within-tileset}
```

- [x] update shared .env file with actual values
- [x] provide values to Netlify 
- [x] verify if it works by using deploy preview