### PR TITLE
fix(#330): Add OSM attribution

### DIFF
--- a/src/assets/content.tsx
+++ b/src/assets/content.tsx
@@ -116,7 +116,7 @@ const content: Content = {
   imprintAndPrivacy: {
     title: 'Impressum und Datenschutz',
     description:
-      '<a target="blank" href="https://www.technologiestiftung-berlin.de/de/impressum/">Impressum</a> und <a target="blank" href="https://www.technologiestiftung-berlin.de/de/datenschutz/">Datenschutz</a>',
+      'Pumpen-Daten © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">OpenStreetMap</a>-Mitwirkende – <a target="blank" href="https://www.technologiestiftung-berlin.de/de/impressum/">Impressum</a> und <a target="blank" href="https://www.technologiestiftung-berlin.de/de/datenschutz/">Datenschutz</a>',
   },
   intro: {
     title: '<b>Gieß den <span>Kiez</span></b>',

--- a/src/assets/content.tsx
+++ b/src/assets/content.tsx
@@ -17,7 +17,11 @@ interface FAQ extends Item {
 }
 interface Content {
   faq: FAQ;
-  imprintAndPrivacy: Item;
+  imprintAndPrivacy: {
+    title: string;
+    description: string;
+    attribution: string;
+  };
   intro: {
     title: string;
     subline: string;
@@ -116,7 +120,9 @@ const content: Content = {
   imprintAndPrivacy: {
     title: 'Impressum und Datenschutz',
     description:
-      'Pumpen-Daten © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">OpenStreetMap</a>-Mitwirkende – <a target="blank" href="https://www.technologiestiftung-berlin.de/de/impressum/">Impressum</a> und <a target="blank" href="https://www.technologiestiftung-berlin.de/de/datenschutz/">Datenschutz</a>',
+      '<a target="blank" href="https://www.technologiestiftung-berlin.de/de/impressum/">Impressum</a> – <a target="blank" href="https://www.technologiestiftung-berlin.de/de/datenschutz/">Datenschutz</a>',
+    attribution:
+      '© <a href="https://www.mapbox.com/about/maps/" target="_blank" rel="noreferrer">Mapbox</a> – © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noreferrer">OpenStreetMap</a> – <a href="https://www.mapbox.com/map-feedback" target="_blank" rel="noreferrer"><strong>Diese Karte verbessern</strong></a>',
   },
   intro: {
     title: '<b>Gieß den <span>Kiez</span></b>',

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -11,7 +11,7 @@ import Cookie from '../Cookie';
 import Loading from '../Loading';
 import Overlay from '../Overlay';
 import Credits from '../Credits';
-import { ImprintAndPrivacy } from '../ImprintAndPrivacy';
+import { MapAttributionImprintAndPrivacy } from '../ImprintAndPrivacy';
 import { useStoreState } from '../../state/unistore-hooks';
 import { useCommunityData } from '../../utils/hooks/useCommunityData';
 import { useRainGeoJson } from '../../utils/hooks/useRainGeoJson';
@@ -42,6 +42,21 @@ const ImprintAndPrivacyContainer = styled.div`
     & > p {
       font-size: 11px;
       line-height: 13px;
+    }
+  }
+`;
+
+const MapboxLogo = styled.a`
+  position: fixed;
+  top: 7px;
+  right: 7px;
+
+  @media screen and (min-width: 767px) {
+    & {
+      top: auto;
+      right: auto;
+      left: 60px;
+      bottom: 7px;
     }
   }
 `;
@@ -78,8 +93,15 @@ const App: FC = () => {
       <Cookie />
       {showMapUI && <MapLayerLegend />}
       <ImprintAndPrivacyContainer>
-        <ImprintAndPrivacy />
+        <MapAttributionImprintAndPrivacy />
       </ImprintAndPrivacyContainer>
+      <MapboxLogo
+        href='http://mapbox.com/about/maps'
+        target='_blank'
+        rel='noreferrer'
+      >
+        <img src="data:image/svg+xml;charset=utf-8,%3Csvg width='88' height='23' viewBox='0 0 88 23' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' fill-rule='evenodd'%3E%3Cdefs%3E%3Cpath id='a' d='M11.5 2.25c5.105 0 9.25 4.145 9.25 9.25s-4.145 9.25-9.25 9.25-9.25-4.145-9.25-9.25 4.145-9.25 9.25-9.25zM6.997 15.983c-.051-.338-.828-5.802 2.233-8.873a4.395 4.395 0 013.13-1.28c1.27 0 2.49.51 3.39 1.42.91.9 1.42 2.12 1.42 3.39 0 1.18-.449 2.301-1.28 3.13C12.72 16.93 7 16 7 16l-.003-.017zM15.3 10.5l-2 .8-.8 2-.8-2-2-.8 2-.8.8-2 .8 2 2 .8z'/%3E%3Cpath id='b' d='M50.63 8c.13 0 .23.1.23.23V9c.7-.76 1.7-1.18 2.73-1.18 2.17 0 3.95 1.85 3.95 4.17s-1.77 4.19-3.94 4.19c-1.04 0-2.03-.43-2.74-1.18v3.77c0 .13-.1.23-.23.23h-1.4c-.13 0-.23-.1-.23-.23V8.23c0-.12.1-.23.23-.23h1.4zm-3.86.01c.01 0 .01 0 .01-.01.13 0 .22.1.22.22v7.55c0 .12-.1.23-.23.23h-1.4c-.13 0-.23-.1-.23-.23V15c-.7.76-1.69 1.19-2.73 1.19-2.17 0-3.94-1.87-3.94-4.19 0-2.32 1.77-4.19 3.94-4.19 1.03 0 2.02.43 2.73 1.18v-.75c0-.12.1-.23.23-.23h1.4zm26.375-.19a4.24 4.24 0 00-4.16 3.29c-.13.59-.13 1.19 0 1.77a4.233 4.233 0 004.17 3.3c2.35 0 4.26-1.87 4.26-4.19 0-2.32-1.9-4.17-4.27-4.17zM60.63 5c.13 0 .23.1.23.23v3.76c.7-.76 1.7-1.18 2.73-1.18 1.88 0 3.45 1.4 3.84 3.28.13.59.13 1.2 0 1.8-.39 1.88-1.96 3.29-3.84 3.29-1.03 0-2.02-.43-2.73-1.18v.77c0 .12-.1.23-.23.23h-1.4c-.13 0-.23-.1-.23-.23V5.23c0-.12.1-.23.23-.23h1.4zm-34 11h-1.4c-.13 0-.23-.11-.23-.23V8.22c.01-.13.1-.22.23-.22h1.4c.13 0 .22.11.23.22v.68c.5-.68 1.3-1.09 2.16-1.1h.03c1.09 0 2.09.6 2.6 1.55.45-.95 1.4-1.55 2.44-1.56 1.62 0 2.93 1.25 2.9 2.78l.03 5.2c0 .13-.1.23-.23.23h-1.41c-.13 0-.23-.11-.23-.23v-4.59c0-.98-.74-1.71-1.62-1.71-.8 0-1.46.7-1.59 1.62l.01 4.68c0 .13-.11.23-.23.23h-1.41c-.13 0-.23-.11-.23-.23v-4.59c0-.98-.74-1.71-1.62-1.71-.85 0-1.54.79-1.6 1.8v4.5c0 .13-.1.23-.23.23zm53.615 0h-1.61c-.04 0-.08-.01-.12-.03-.09-.06-.13-.19-.06-.28l2.43-3.71-2.39-3.65a.213.213 0 01-.03-.12c0-.12.09-.21.21-.21h1.61c.13 0 .24.06.3.17l1.41 2.37 1.4-2.37a.34.34 0 01.3-.17h1.6c.04 0 .08.01.12.03.09.06.13.19.06.28l-2.37 3.65 2.43 3.7c0 .05.01.09.01.13 0 .12-.09.21-.21.21h-1.61c-.13 0-.24-.06-.3-.17l-1.44-2.42-1.44 2.42a.34.34 0 01-.3.17zm-7.12-1.49c-1.33 0-2.42-1.12-2.42-2.51 0-1.39 1.08-2.52 2.42-2.52 1.33 0 2.42 1.12 2.42 2.51 0 1.39-1.08 2.51-2.42 2.52zm-19.865 0c-1.32 0-2.39-1.11-2.42-2.48v-.07c.02-1.38 1.09-2.49 2.4-2.49 1.32 0 2.41 1.12 2.41 2.51 0 1.39-1.07 2.52-2.39 2.53zm-8.11-2.48c-.01 1.37-1.09 2.47-2.41 2.47s-2.42-1.12-2.42-2.51c0-1.39 1.08-2.52 2.4-2.52 1.33 0 2.39 1.11 2.41 2.48l.02.08zm18.12 2.47c-1.32 0-2.39-1.11-2.41-2.48v-.06c.02-1.38 1.09-2.48 2.41-2.48s2.42 1.12 2.42 2.51c0 1.39-1.09 2.51-2.42 2.51z'/%3E%3C/defs%3E%3Cmask id='c'%3E%3Crect width='100%25' height='100%25' fill='%23fff'/%3E%3Cuse xlink:href='%23a'/%3E%3Cuse xlink:href='%23b'/%3E%3C/mask%3E%3Cg opacity='.3' stroke='%23000' stroke-width='3'%3E%3Ccircle mask='url(%23c)' cx='11.5' cy='11.5' r='9.25'/%3E%3Cuse xlink:href='%23b' mask='url(%23c)'/%3E%3C/g%3E%3Cg opacity='.9' fill='%23fff'%3E%3Cuse xlink:href='%23a'/%3E%3Cuse xlink:href='%23b'/%3E%3C/g%3E%3C/svg%3E" />
+      </MapboxLogo>
     </AppContainer>
   );
 };

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -27,10 +27,23 @@ const AppContainer = styled.div`
 const ImprintAndPrivacyContainer = styled.div`
   position: fixed;
   bottom: 7px;
-  right: 16px;
+  right: 7px;
   width: auto;
-  height: 24px;
+  height: auto;
+  max-width: 80vw;
   z-index: 2;
+  text-align: right;
+
+  @media screen and (max-width: 767px) {
+    & {
+      bottom: 4px;
+    }
+
+    & > p {
+      font-size: 11px;
+      line-height: 13px;
+    }
+  }
 `;
 
 const App: FC = () => {

--- a/src/components/ImprintAndPrivacy/index.tsx
+++ b/src/components/ImprintAndPrivacy/index.tsx
@@ -13,3 +13,12 @@ export const ImprintAndPrivacy: FC = () => (
     {content.imprintAndPrivacy.description}
   </ImprintAndPrivacySpan>
 );
+
+export const MapAttributionImprintAndPrivacy: FC = () => (
+  <ImprintAndPrivacySpan>
+    {[
+      content.imprintAndPrivacy.attribution,
+      content.imprintAndPrivacy.description,
+    ].join(' – ')}
+  </ImprintAndPrivacySpan>
+);

--- a/src/components/ImprintAndPrivacy/index.tsx
+++ b/src/components/ImprintAndPrivacy/index.tsx
@@ -5,7 +5,6 @@ import content from '../../assets/content';
 import styled from 'styled-components';
 
 const ImprintAndPrivacySpan = styled(SmallParagraph)`
-  text-align: center;
   display: block;
 `;
 

--- a/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
+++ b/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
@@ -574,7 +574,7 @@ exports[`Storyshots Sidebar Profile Loading 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -640,7 +640,7 @@ exports[`Storyshots Sidebar Profile Logged In No Data 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -706,7 +706,7 @@ exports[`Storyshots Sidebar Profile Logged In With Data 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -772,7 +772,7 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -1361,7 +1361,7 @@ exports[`Storyshots Sidebar Tree 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -1427,7 +1427,7 @@ exports[`Storyshots Sidebar Tree Loading 1`] = `
       className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}

--- a/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
+++ b/src/components/Sidebar/__snapshots__/Sidebar.stories.storyshot
@@ -571,10 +571,10 @@ exports[`Storyshots Sidebar Profile Loading 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -637,10 +637,10 @@ exports[`Storyshots Sidebar Profile Logged In No Data 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -703,10 +703,10 @@ exports[`Storyshots Sidebar Profile Logged In With Data 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -769,10 +769,10 @@ exports[`Storyshots Sidebar Profile Logged Out 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -1358,10 +1358,10 @@ exports[`Storyshots Sidebar Tree 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}
@@ -1424,10 +1424,10 @@ exports[`Storyshots Sidebar Tree Loading 1`] = `
       </div>
     </div>
     <p
-      className="sc-gtsrHT hDlbRR sc-bTDOke cXWAhw"
+      className="sc-gtsrHT hDlbRR sc-bTDOke duGiTB"
       dangerouslySetInnerHTML={
         Object {
-          "__html": "<a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
+          "__html": "Pumpen-Daten © <a href=\\"https://www.openstreetmap.org/copyright\\" target=\\"_blank\\" rel=\\"noreferrer\\">OpenStreetMap</a>-Mitwirkende – <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/impressum/\\">Impressum</a> und <a target=\\"blank\\" href=\\"https://www.technologiestiftung-berlin.de/de/datenschutz/\\">Datenschutz</a>",
         }
       }
       onClick={[Function]}


### PR DESCRIPTION
This PR attempts to add the correct OpenStreetMap attribution to the map, as indicated by @joshinils on #330. I followed a combination of the [OSM attribution guideline](https://www.openstreetmap.org/copyright) and the [Mapbox attribution guideline](https://docs.mapbox.com/help/getting-started/attribution/), but I'm not 100% sure if my implementation fulfills your requirements @joshinils. So let me know.

**Edit:** I also added the Mapbox attribution and logo. Now we should be fine.

<img width="286" alt="Screen Shot 2021-08-16 at 9 13 01 AM" src="https://user-images.githubusercontent.com/2759340/129529836-51beb8c0-8251-483b-848e-a6ccb8838ff7.png">
<img width="1069" alt="Screen Shot 2021-08-16 at 11 24 07 AM" src="https://user-images.githubusercontent.com/2759340/129541657-d6430d56-ca75-45c0-b1ba-bd6d0f0a515e.png">
<img width="323" alt="Screen Shot 2021-08-16 at 11 24 29 AM" src="https://user-images.githubusercontent.com/2759340/129541680-4011b8d4-1b67-494b-b870-fc627cffd947.png">

