### PR TITLE
fix(#379): Fix the bug that ageless watered or adopted trees aren't shown

### DIFF
--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -171,16 +171,19 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
       (mapWaterNeedFilter && waterNeed !== mapWaterNeedFilter) ||
       !rainDataExists;
 
+	if (id === "_2100157b5d") {
+		debugger
+	}
     if (colorShallBeTransparent) return colors.transparent;
 
     if (mapViewFilter === 'watered') {
-      return communityDataFlatMap && isWatered && treeIsWithinAgeRange
+		return communityDataFlatMap && isWatered && (ageFilterIsApplied ? treeIsWithinAgeRange : true)
         ? colors.blue
         : colors.transparent;
     }
 
     if (mapViewFilter === 'adopted') {
-      return communityDataFlatMap && isAdopted && treeIsWithinAgeRange
+		return communityDataFlatMap && isAdopted && (ageFilterIsApplied ? treeIsWithinAgeRange : true)
         ? colors.turquoise
         : colors.transparent;
     }
@@ -537,6 +540,7 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
           true,
           false,
         ];
+		  debugger
       } else if (this.props.mapViewFilter === 'adopted') {
         communityFilter = [
           'match',

--- a/src/components/TreesMap/DeckGLMap.tsx
+++ b/src/components/TreesMap/DeckGLMap.tsx
@@ -171,19 +171,20 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
       (mapWaterNeedFilter && waterNeed !== mapWaterNeedFilter) ||
       !rainDataExists;
 
-	if (id === "_2100157b5d") {
-		debugger
-	}
     if (colorShallBeTransparent) return colors.transparent;
 
     if (mapViewFilter === 'watered') {
-		return communityDataFlatMap && isWatered && (ageFilterIsApplied ? treeIsWithinAgeRange : true)
+      return communityDataFlatMap &&
+        isWatered &&
+        (ageFilterIsApplied ? treeIsWithinAgeRange : true)
         ? colors.blue
         : colors.transparent;
     }
 
     if (mapViewFilter === 'adopted') {
-		return communityDataFlatMap && isAdopted && (ageFilterIsApplied ? treeIsWithinAgeRange : true)
+      return communityDataFlatMap &&
+        isAdopted &&
+        (ageFilterIsApplied ? treeIsWithinAgeRange : true)
         ? colors.turquoise
         : colors.transparent;
     }
@@ -540,7 +541,6 @@ class DeckGLMap extends React.Component<DeckGLPropType, DeckGLStateType> {
           true,
           false,
         ];
-		  debugger
       } else if (this.props.mapViewFilter === 'adopted') {
         communityFilter = [
           'match',


### PR DESCRIPTION
...when the relevate (Bereits adopted | In den letzten 30 Tagen gegossen) filter is active. Fixes #379 

The problem concerned all trees that were either adopted or watered in the last 30 days and had no age. Ad condition checked whether the tree was within the age range defined by the filter. Now the age range is only checked if the age filter is active.