### PR TITLE
chore(Matomo): do not set cookies

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -96,6 +96,7 @@
     _paq.push(["setDoNotTrack", true]);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
+    _paq.push(['requireCookieConsent']);
     (function() {
       var u="https://piwik.technologiestiftung-berlin.de/";
       _paq.push(['setTrackerUrl', u+'matomo.php']);


### PR DESCRIPTION
To conform to GDPR requirements, this PR disables the use of cookies by Matomo.

Note that analytics with Matomo will still work, it's just anonymized and without the use of cookies. See [the same implementation in Berlin Open Source](https://github.com/technologiestiftung/berlin-open-source-portal/blob/3f9292eda39c65f8f98face3a73a5c65d4a7b431/src/_includes/layouts/root.liquid#L28) for which analytics in Matomo are still available.

-> [Context](https://matomo.org/faq/new-to-piwik/how-do-i-use-matomo-analytics-without-consent-or-cookie-banner/)