### PR TITLE
fix: watering modal (error CSS + watering only as integer)

### DIFF
--- a/src/components/WateringModal/index.tsx
+++ b/src/components/WateringModal/index.tsx
@@ -25,9 +25,13 @@ const ButtonsContainer = styled.div`
 `;
 
 const StyledError = styled.p`
-  grid-column: 1 / 3;
+  grid-column: 1 / 2;
   color: ${p => p.theme.colorAlarm};
   margin: 0;
+
+  @media (min-width: ${p => p.theme.screenWidthS}) {
+    grid-column: 1 / 3;
+  }
 `;
 
 export const WateringModal: FC<{

--- a/src/components/WateringModal/index.tsx
+++ b/src/components/WateringModal/index.tsx
@@ -51,6 +51,10 @@ export const WateringModal: FC<{
       setError('Bitte gieße mindestens 1 Liter.');
       return;
     }
+    if (!Number.isInteger(wateringValue)) {
+      setError('Bitte gib eine volle Literzahl an.');
+      return;
+    }
     if (wateringValue >= 1000) {
       setError('Eine so große Bewässerung kann nicht eingetragen werden.');
       return;


### PR DESCRIPTION
This PR fixes two issues with the watering modal:

- the error message on mobile doesn't change the grid of the inputs
- watering is only allowed as an integer (client-side validation)