### PR TITLE
fix(GDK-203): use map's pitch also for trees

### DIFF
--- a/src/components/TreesMap/TreesMap.tsx
+++ b/src/components/TreesMap/TreesMap.tsx
@@ -325,6 +325,7 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(
           'source-layer': process.env.MAPBOX_TREES_TILESET_LAYER,
           interactive: true,
           paint: {
+            'circle-pitch-alignment': 'map',
             'circle-radius': getTreeCircleRadius({}),
             'circle-opacity': [
               'interpolate',


### PR DESCRIPTION
This PR makes sure that the trees are rendered with the same pitch as the map. This makes them look more realistic.