### PR TITLE
refactor(GDK-207): improve initial loading

### DIFF
--- a/src/assets/Global.tsx
+++ b/src/assets/Global.tsx
@@ -21,7 +21,7 @@ export default createGlobalStyle`
   }
 
   .fade {
-    animation: fadein 1.5s;
+    animation: fadein .5s;
   }
 
   @keyframes fadein {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -57,6 +57,7 @@ export interface StoreProps {
   ageRange: number[];
   overlay: boolean;
   mapFocusPoint: FocusPointType | null;
+  mapHasLoaded: boolean | undefined;
 }
 
 export interface Tree {

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -8,16 +8,13 @@ import Sidebar from '../Sidebar';
 import Nav from '../Nav';
 import MapLayerLegend from '../Legend/MapLayersLegend';
 import Cookie from '../Cookie';
-import Loading from '../Loading';
 import Overlay from '../Overlay';
 import Credits from '../Credits';
 import { MapAttributionImprintAndPrivacy } from '../ImprintAndPrivacy';
 import { useStoreState } from '../../state/unistore-hooks';
-import { useCommunityData } from '../../utils/hooks/useCommunityData';
-import { useRainGeoJson } from '../../utils/hooks/useRainGeoJson';
-import { usePumpsGeoJson } from '../../utils/hooks/usePumpsGeoJson';
 
 import 'react-day-picker/dist/style.css';
+import Loading from '../Loading';
 
 const AppContainer = styled.div`
   font-family: ${({ theme: { fontFamily } }): string => fontFamily};
@@ -65,25 +62,19 @@ const MapboxLogo = styled.a`
 const App: FC = () => {
   const overlay = useStoreState('overlay');
   const isNavOpen = useStoreState('isNavOpen');
+  const mapHasLoaded = useStoreState('mapHasLoaded');
 
-  const { data: communityData } = useCommunityData();
-  const { data: rainGeoJson } = useRainGeoJson();
-  const { data: pumpsGeoJson } = usePumpsGeoJson();
   const { pathname } = useLocation();
 
   const isHome = pathname === '/';
   const showOverlay = isHome && overlay;
-  const showMap = Boolean(communityData && rainGeoJson && pumpsGeoJson);
-  const showLoading = !showMap;
-  const showMapUI = showMap && !showOverlay;
+  const showMapUI = !showOverlay;
   const isSidebarOpened = !isHome && isNavOpen;
 
   return (
     <AppContainer>
-      {showLoading && <Loading />}
-      {showMap && (
-        <Map isNavOpened={isSidebarOpened} showOverlay={showOverlay} />
-      )}
+      {!mapHasLoaded && <Loading />}
+      <Map isNavOpened={isSidebarOpened} showOverlay={showOverlay} />
       {showMapUI && <Sidebar />}
       {showOverlay && <Overlay />}
       {showMapUI && <Nav isNavOpened={!isHome} />}

--- a/src/components/TreesMap/TreesMap.tsx
+++ b/src/components/TreesMap/TreesMap.tsx
@@ -42,6 +42,7 @@ import {
   HIGH_WATER_NEED_NUM,
 } from '../../utils/getWaterNeedByAge';
 import DeckGL from 'deck.gl';
+import { useActions } from '../../state/unistore-hooks';
 
 const VIEWSTATE_TRANSITION_DURATION = 1000;
 const VIEWSTATE_ZOOMEDIN_ZOOM = 19;
@@ -154,6 +155,7 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(
       null
     );
     const [viewport, setViewport] = useState<ViewportType>(defaultViewport);
+    const { setMapHasLoaded } = useActions();
     const pumpInfo = clickedPump || hoveredPump;
 
     useEffect(
@@ -263,6 +265,8 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(
 
         if (!map.current || typeof map.current === 'undefined' || hasUnmounted)
           return;
+
+        setMapHasLoaded();
 
         const firstLabelLayerId = map.current
           .getStyle()

--- a/src/state/Actions.tsx
+++ b/src/state/Actions.tsx
@@ -37,6 +37,10 @@ const closeNav = (): { isNavOpen: StoreProps['isNavOpen'] } => ({
   isNavOpen: false,
 });
 
+const setMapHasLoaded = (): { mapHasLoaded: StoreProps['mapHasLoaded'] } => ({
+  mapHasLoaded: true,
+});
+
 const allActions = {
   setMapFocusPoint,
   setAgeRange,
@@ -47,6 +51,7 @@ const allActions = {
   setVisibleMapLayer,
   setMapViewFilter,
   setMapWaterNeedFilter,
+  setMapHasLoaded,
 };
 
 export type ActionsType = typeof allActions;

--- a/src/state/Store.tsx
+++ b/src/state/Store.tsx
@@ -9,6 +9,7 @@ const initialState: StoreProps = {
   ageRange: [0, 320],
   overlay: true,
   mapFocusPoint: null,
+  mapHasLoaded: undefined,
 };
 
 const store = createStore<StoreProps>(initialState);


### PR DESCRIPTION
This PR shortens the initial loading time. We used to have sort of an "artificial" delay because we would only start loading the map once an initial call for **all of community data, adopted data and watered data** had finished.

We don't need this anymore (and potentially we had never needed it). The map component itself now handles the fetching of all the above data and only renders the appropriate layers once the data has been fetched. So, the initial call in `App.tsx` was delaying the map load unnecessarily.

I would suggest we still keep the loading screen, but start loading the map immediately and remove the screen once the map's `onLoad` function was triggered (this is achieved with setting a state `mapHasLoaded` on `onLoad`).