### PR TITLE
refactor(GDK-210): Optimize parsing of community data

### DIFF
--- a/src/components/TreesMap/TreesMap.tsx
+++ b/src/components/TreesMap/TreesMap.tsx
@@ -419,7 +419,14 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(
     }, [visibleMapLayer]);
 
     useEffect(() => {
-      if (!map?.current || hasUnmounted) return;
+      if (
+        !map?.current ||
+        hasUnmounted ||
+        !communityDataWatered.length ||
+        Object.keys(communityDataAdopted).length === 0
+      )
+        return;
+
       updateTreeCirclePaintProps({
         map: map.current,
         wateredFilterOn: mapViewFilter === 'watered',

--- a/src/utils/requests/getCommunityData.ts
+++ b/src/utils/requests/getCommunityData.ts
@@ -35,17 +35,19 @@ export const getCommunityData = async (): Promise<CommunityDataType> => {
     (acc: CommunityDataType, { tree_id: id, adopted, watered }) => {
       const isAdopted = adopted !== '0';
       const isWatered = watered !== '0';
+
+      const newCommunityFlagsMap = acc.communityFlagsMap || {};
+      newCommunityFlagsMap[id] = { isAdopted, isWatered };
+
+      const newWateredTreesIds = acc.wateredTreesIds;
+      if (isWatered) newWateredTreesIds.push(id);
+
+      const newAdoptedTreesIds = acc.adoptedTreesIds;
+      if (isAdopted) newAdoptedTreesIds[id] = parseInt(adopted, 10) || 0;
       return {
-        communityFlagsMap: {
-          ...acc.communityFlagsMap,
-          [id]: { isAdopted, isWatered },
-        },
-        wateredTreesIds: isWatered
-          ? [...acc.wateredTreesIds, id]
-          : acc.wateredTreesIds,
-        adoptedTreesIds: isAdopted
-          ? { ...acc.adoptedTreesIds, [id]: parseInt(adopted, 10) || 0 }
-          : acc.adoptedTreesIds,
+        communityFlagsMap: newCommunityFlagsMap,
+        wateredTreesIds: newWateredTreesIds,
+        adoptedTreesIds: newAdoptedTreesIds,
       };
     },
     defaultCommunityData


### PR DESCRIPTION
This PR fixes the unresponsive UI that was occurring when the "community data" was busy loading and blocking the main thread. This fix makes the parsing of the community data more efficient by removing the spread syntax.

Note that the frozen UI was only occurring in the production environment because the production database has lots more adopted trees than the development database. To be able to see the difference that this change makes, you will have to locally update your `API_ENDPOINT` variable to use the production API.