### PR TITLE
refactor: edit account action

### DIFF
--- a/src/components/AccountEditModal/index.tsx
+++ b/src/components/AccountEditModal/index.tsx
@@ -20,9 +20,13 @@ export const AccountEditModal: FC<AccountEditModalProps> = ({ onClose }) => {
             placeContent: 'space-between',
           }}
         >
-          {successMessages.map(msg => {
-            return <UserNotification key={msg} message={msg} type='success' />;
-          })}
+          <div style={{ display: 'grid', gap: '16px' }}>
+            {successMessages.map(msg => {
+              return (
+                <UserNotification key={msg} message={msg} type='success' />
+              );
+            })}
+          </div>
           <div style={{ paddingTop: '40px' }}>
             <ButtonRound width='fit-content' onClick={onClose}>
               Schließen

--- a/src/components/AccountEditModal/index.tsx
+++ b/src/components/AccountEditModal/index.tsx
@@ -23,10 +23,11 @@ export const AccountEditModal: FC<AccountEditModalProps> = ({ onClose }) => {
           {successMessages.map(msg => {
             return <UserNotification key={msg} message={msg} type='success' />;
           })}
-
-          <ButtonRound width='fit-content' onClick={onClose}>
-            Schließen
-          </ButtonRound>
+          <div style={{ paddingTop: '40px' }}>
+            <ButtonRound width='fit-content' onClick={onClose}>
+              Schließen
+            </ButtonRound>
+          </div>
         </div>
       ) : (
         <AccountEditForm

--- a/src/components/AccountEditModal/index.tsx
+++ b/src/components/AccountEditModal/index.tsx
@@ -1,18 +1,39 @@
-import React, { FC, HTMLProps } from 'react';
+import React, { FC, useState } from 'react';
 import { Modal } from '../Modal';
 import { AccountEditForm } from '../Forms/AccountEditForm';
+import ButtonRound from '../ButtonRound';
+import { UserNotification } from '../Notification';
 
-export interface AccountEditModalProps extends HTMLProps<HTMLElement> {
-  isOpen?: boolean;
-  setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+export interface AccountEditModalProps {
+  onClose: () => void;
 }
-export const AccountEditModal: FC<AccountEditModalProps> = ({
-  isOpen = false,
-  setIsOpen,
-}) => {
+export const AccountEditModal: FC<AccountEditModalProps> = ({ onClose }) => {
+  const [successMessages, setSuccessMessages] = useState<string[] | null>(null);
   return (
-    <Modal title={'Account bearbeiten'} isOpen={isOpen} setIsOpen={setIsOpen}>
-      <AccountEditForm isOpen={isOpen} setIsOpen={setIsOpen}></AccountEditForm>
+    <Modal title={'Account bearbeiten'} isOpen={true} setIsOpen={onClose}>
+      {successMessages ? (
+        <div
+          style={{
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+            placeContent: 'space-between',
+          }}
+        >
+          {successMessages.map(msg => {
+            return <UserNotification key={msg} message={msg} type='success' />;
+          })}
+
+          <ButtonRound width='fit-content' onClick={onClose}>
+            Schließen
+          </ButtonRound>
+        </div>
+      ) : (
+        <AccountEditForm
+          onSuccess={messages => setSuccessMessages(messages)}
+          onCancel={onClose}
+        ></AccountEditForm>
+      )}
     </Modal>
   );
 };

--- a/src/components/Forms/AccountEditForm/index.tsx
+++ b/src/components/Forms/AccountEditForm/index.tsx
@@ -52,6 +52,9 @@ export const AccountEditForm: FC<AccountEditFormProps> = ({
   const [errorNotifications, setErrorNotifications] = useState<string[] | null>(
     null
   );
+  const [successNotifications, setSuccessNotifications] = useState<
+    string[] | null
+  >(null);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -92,6 +95,7 @@ export const AccountEditForm: FC<AccountEditFormProps> = ({
 
     if (errorMessages.length >= 1) {
       setErrorNotifications(errorMessages);
+      setSuccessNotifications(successMessages);
     }
 
     if (errorMessages.length === 0 && successMessages.length >= 1) {
@@ -130,9 +134,25 @@ export const AccountEditForm: FC<AccountEditFormProps> = ({
             required
           />
         </StyledInputContainer>
+        {successNotifications &&
+          successNotifications.map(successNotification => {
+            return (
+              <UserNotification
+                key={successNotification}
+                message={successNotification}
+                type='success'
+              />
+            );
+          })}
         {errorNotifications &&
-          errorNotifications.map(not => {
-            return <UserNotification key={not} message={not} type='error' />;
+          errorNotifications.map(errorNotification => {
+            return (
+              <UserNotification
+                key={errorNotification}
+                message={errorNotification}
+                type='error'
+              />
+            );
           })}
       </StyledGrid>
       <StyledButtonsContainer>

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -29,7 +29,7 @@ const StyledDiv = styled.div<StyledMessageProps>`
   color: ${p => p.theme.colorTextDark};
   padding: 10px;
   border-radius: 5px;
-  margin: 10px 0;
+  margin: 0;
 `;
 
 export const UserNotification = ({

--- a/src/components/UserCredentials/index.tsx
+++ b/src/components/UserCredentials/index.tsx
@@ -18,12 +18,14 @@ const CardCredentials: FC<{
 }> = ({ username, email }) => {
   const [isEditingAccount, setIsEditingAccount] = useState(false);
   const [isEditingPassword, setIsEditingPassword] = useState(false);
+
   return (
     <>
-      <AccountEditModal
-        isOpen={isEditingAccount}
-        setIsOpen={setIsEditingAccount}
-      ></AccountEditModal>
+      {isEditingAccount && (
+        <AccountEditModal
+          onClose={() => setIsEditingAccount(false)}
+        ></AccountEditModal>
+      )}
       {isEditingPassword && (
         <PasswordEditModal onClose={() => setIsEditingPassword(false)} />
       )}

--- a/src/utils/requests/getUsernameBySession.ts
+++ b/src/utils/requests/getUsernameBySession.ts
@@ -1,0 +1,21 @@
+import {
+  Session,
+  createBrowserSupabaseClient,
+} from '@supabase/auth-helpers-nextjs';
+import { Database } from '../../common/database';
+
+const supabase = createBrowserSupabaseClient<Database>();
+
+export const getUsernameBySession = async (session: Session) => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', session?.user?.id);
+
+  if (error) throw new Error('Benutzername konnte nicht gefunden werden');
+
+  if (data.length > 1)
+    throw new Error('Benutzername konnte nicht eindeutig identifiziert werden');
+
+  return data[0].username;
+};

--- a/src/utils/requests/updateAccount.ts
+++ b/src/utils/requests/updateAccount.ts
@@ -14,6 +14,10 @@ interface UpdateAccountReturnType {
   errorMessages: string[];
 }
 
+/**
+ * Updates the email (`users` table) and the username (`profiles` table)
+ * if the new values differ from the existing ones.
+ */
 export const updateAccount = async ({
   currentSession,
   newUsername,

--- a/src/utils/requests/updateAccount.ts
+++ b/src/utils/requests/updateAccount.ts
@@ -1,0 +1,63 @@
+import { Session } from '@supabase/auth-helpers-react';
+import { updateEmail } from './updateEmail';
+import { updateUsername } from './updateUsername';
+import { getUsernameBySession } from './getUsernameBySession';
+
+interface updateAccountPropType {
+  newEmail: string;
+  newUsername: string;
+  currentSession: Session | null;
+}
+
+interface UpdateAccountReturnType {
+  successMessages: string[];
+  errorMessages: string[];
+}
+
+export const updateAccount = async ({
+  currentSession,
+  newUsername,
+  newEmail,
+}: updateAccountPropType): Promise<UpdateAccountReturnType> => {
+  const successMessages: string[] = [];
+  const errorMessages: string[] = [];
+
+  if (!currentSession) {
+    return {
+      successMessages: [],
+      errorMessages: ['Du bist im Moment nicht authentifiziert'],
+    };
+  }
+
+  if (newEmail !== currentSession.user.email) {
+    try {
+      const emailSuccessMessage = await updateEmail(newEmail);
+      emailSuccessMessage && successMessages.push(emailSuccessMessage);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      errorMessages.push(errorMessage);
+    }
+  }
+
+  const currentUsername = await getUsernameBySession(currentSession);
+
+  if (newUsername !== currentUsername) {
+    try {
+      const usernameSuccessMessage = await updateUsername(
+        newUsername,
+        currentSession
+      );
+      usernameSuccessMessage && successMessages.push(usernameSuccessMessage);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      errorMessages.push(errorMessage);
+    }
+  }
+
+  return {
+    successMessages: successMessages,
+    errorMessages: errorMessages,
+  };
+};

--- a/src/utils/requests/updateEmail.ts
+++ b/src/utils/requests/updateEmail.ts
@@ -1,0 +1,16 @@
+import {
+  Session,
+  createBrowserSupabaseClient,
+} from '@supabase/auth-helpers-nextjs';
+import { Database } from '../../common/database';
+
+const supabase = createBrowserSupabaseClient<Database>();
+
+export const updateEmail = async (newEmail: string): Promise<string> => {
+  const { error } = await supabase.auth.updateUser({
+    email: newEmail,
+  });
+  if (error) throw new Error('E-Mail konnte nicht gespeichert werden');
+
+  return 'E-Mail wurde geändert. Bitte bestätige die Änderung über den Link in der E-Mail, die wir dir geschickt haben.';
+};

--- a/src/utils/requests/updateEmail.ts
+++ b/src/utils/requests/updateEmail.ts
@@ -12,5 +12,5 @@ export const updateEmail = async (newEmail: string): Promise<string> => {
   });
   if (error) throw new Error('E-Mail konnte nicht gespeichert werden');
 
-  return 'E-Mail wurde geändert. Bitte bestätige die Änderung über den Link in der E-Mail, die wir dir geschickt haben.';
+  return 'E-Mail geändert. Bitte klicke die Links in den Mails an deine alte UND neue E-Mail-Adresse, um die Änderung zu bestätigen.';
 };

--- a/src/utils/requests/updateUsername.ts
+++ b/src/utils/requests/updateUsername.ts
@@ -1,0 +1,33 @@
+import {
+  Session,
+  createBrowserSupabaseClient,
+} from '@supabase/auth-helpers-nextjs';
+import { Database } from '../../common/database';
+import { isUsernameUnique } from './validateUsernameUniqueness';
+
+const supabase = createBrowserSupabaseClient<Database>();
+
+export const updateUsername = async (
+  newUsername: string,
+  session?: Session | null
+): Promise<string> => {
+  const newUsernameIsUnique = await isUsernameUnique(newUsername);
+
+  if (!newUsernameIsUnique) {
+    throw new Error('Benutzername ist bereits vergeben');
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .update({ username: newUsername })
+    .eq('id', session?.user?.id)
+    .select();
+
+  if (error || !data) {
+    throw new Error(
+      'Interner Fehler beim Speichern des neuen Namens. Bitte versuch es später erneut.'
+    );
+  }
+
+  return 'Benutzername geändert.';
+};

--- a/src/utils/requests/validateUsernameUniqueness.ts
+++ b/src/utils/requests/validateUsernameUniqueness.ts
@@ -1,0 +1,27 @@
+import {
+  Session,
+  createBrowserSupabaseClient,
+} from '@supabase/auth-helpers-nextjs';
+import { Database } from '../../common/database';
+
+const supabase = createBrowserSupabaseClient<Database>();
+
+export const isUsernameUnique = async (
+  username: string
+): Promise<boolean | undefined> => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('username', username);
+
+  if (error || !data) {
+    console.error(error);
+    return;
+  }
+
+  const userNameExists = data
+    .map(({ username }) => username)
+    .includes(username);
+
+  return !userNameExists;
+};

--- a/src/utils/requests/validateUsernameUniqueness.ts
+++ b/src/utils/requests/validateUsernameUniqueness.ts
@@ -15,7 +15,7 @@ export const isUsernameUnique = async (
     .eq('username', username);
 
   if (error || !data) {
-    console.error(error);
+    console.error(error || 'Failed to validate username uniqueness');
     return;
   }
 


### PR DESCRIPTION
This PR refactors the edit account modal. It ensures that all error and success messages are displayed to the user.

## Step 1 : Default View

![Screen Shot 2023-04-19 at 15 10 30](https://user-images.githubusercontent.com/15640196/233085283-ad730c8b-9db1-4dd2-9af2-a351d7cd3be0.png)

## Step 2 : Error State

![Screen Shot 2023-04-19 at 15 10 44](https://user-images.githubusercontent.com/15640196/233085339-2e9b49ba-96c0-428a-b023-9c2884310fcf.png)

## Step 3 : Success State

![Screen Shot 2023-04-19 at 15 11 16](https://user-images.githubusercontent.com/15640196/233085436-1f079ab5-8c39-4734-a437-7789b80d6d28.png)


## Open To-Do's:
- [x] reorganize requests for better maintainability
- [x] display error/success messages appropriately
- [x] make sure updated username is displayed in sidebar without page refresh
- [x] ~~check why email change doesn't work in local setup~~ -> Because we have to click the links in both the old _and_ new e-mail inbox
- [x] ~~discuss testing strategy (maybe some UI tests with the local Supabase setup?)~~ -> For now we stick with the unit tests, setting up E2E tests is a big undertaking and should be handled in a different PR