### PR TITLE
adds and uses env var "NEXT_PUBLIC_RAIN_DATA_URL"

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,9 +10,13 @@ NEXT_PUBLIC_MAPBOX_API_KEY=pk.123.xyz
 NEXT_PUBLIC_MAPBOX_TREES_TILESET_URL=mapbox://{username}.{tilesetId}
 NEXT_PUBLIC_MAPBOX_TREES_TILESET_LAYER={layer-name-within-tileset}
 
+# Weather data source
+NEXT_PUBLIC_RAIN_DATA_URL=https://tsb-trees.s3.eu-central-1.amazonaws.com/weather_light.geojson.gz
+
 # Map variables
 #                min longitude    min latitude     max longitude    max latitude
 NEXT_PUBLIC_MAP_BOUNDING_BOX=13.0824446341071,52.3281202651866,13.7682544186827,52.681600197973
+
 NEXT_PUBLIC_MAP_INITIAL_LATITUDE=52.500869
 NEXT_PUBLIC_MAP_INITIAL_LONGITUDE=13.419047
 NEXT_PUBLIC_MAP_INITIAL_ZOOM=11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ env:
   NEXT_PUBLIC_MAPBOX_TREES_TILESET_URL: mapbox://{username}.{tilesetId}
   NEXT_PUBLIC_MAP_BOUNDING_BOX: 13.0824446341071,52.3281202651866,13.7682544186827,52.681600197973
   NEXT_PUBLIC_MAPBOX_API_KEY: pk.123.xyz
+  NEXT_PUBLIC_RAIN_DATA_URL: https://tsb-trees.s3.eu-central-1.amazonaws.com/weather_light.geojson.gz
   NEXT_PUBLIC_BASE_URL: http://localhost:3000
   NEXT_TELEMETRY_DISABLED: '1'
   NODE_ENV: test

--- a/src/utils/requests/loadRainGeoJson.ts
+++ b/src/utils/requests/loadRainGeoJson.ts
@@ -3,7 +3,7 @@ import { requests } from '../requestUtil';
 
 export const loadRainGeoJson = async (): Promise<ExtendedFeatureCollection> => {
   const dataUrl =
-    'https://tsb-trees.s3.eu-central-1.amazonaws.com/weather_light.geojson.gz';
+    process.env.NEXT_PUBLIC_RAIN_DATA_URL || 'https://tsb-trees.s3.eu-central-1.amazonaws.com/weather_light.geojson.gz';
 
   return await requests<ExtendedFeatureCollection>(dataUrl);
 };


### PR DESCRIPTION
Introduces the environment variable "NEXT_PUBLIC_RAIN_DATA_URL". It should contain the address of the rain data geojson file (Usually points to a file within an S3 bucket).

This avoids using a hard-coded address. Now it is possible to inject any url by setting up the hosting environment.

When omitted the Berlin weather data address is used.