### PR TITLE
docs: Added new env var to vercel and test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ env:
   NEXT_PUBLIC_SUPABASE_ANON_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
   NEXT_PUBLIC_API_ENDPOINT: https://localhost:8000/my-local-postgres-api
   NEXT_PUBLIC_BASE_URL: http://localhost:3000
+  NEXT_PUBLIC_RECOVERY_AUTH_REDIRECT_URL: http://localhost:3000/auth
   NEXT_TELEMETRY_DISABLED: '1'
   #mapbox related
   NEXT_PUBLIC_MAPBOX_TREES_TILESET_LAYER: layer-name-within-tileset


### PR DESCRIPTION
This PR adds the new env var NEXT_PUBLIC_RECOVERY_AUTH_REDIRECT_URL=${NEXT_PUBLIC_BASE_URL}/auth
to vercel.com and to the test run for documentation purpose.