### PR TITLE
Show water + rain sum in tree side bar

### DIFF
--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -162,7 +162,10 @@ const TreeInfos: FC<{
   }, [waterings]);
 
   const rainSum = useMemo(() => {
-    const last30Days = selectedTreeData.radolan_days.slice(-30);
+    // reverse because last element is most recent rain
+    const last30Days = selectedTreeData.radolan_days
+      .reverse()
+      .slice(-(30 * 24));
     return last30Days.reduce((sum, current) => sum + current, 0);
   }, [selectedTreeData.radolan_days]);
 
@@ -232,13 +235,15 @@ const TreeInfos: FC<{
               <div>
                 <BaselineGrid>
                   <span>{wateredCircle}</span>
-                  <SmallParagraph>Gießungen: {wateringsSum}l</SmallParagraph>
+                  <SmallParagraph>
+                    Gießungen: {wateringsSum.toFixed(1)}l
+                  </SmallParagraph>
                 </BaselineGrid>
               </div>
               <div>
                 <BaselineGrid>
                   <span>{rainCircle}</span>
-                  <SmallParagraph>Regen: {rainSum}l</SmallParagraph>
+                  <SmallParagraph>Regen: {rainSum.toFixed(1)}l</SmallParagraph>
                 </BaselineGrid>
               </div>
             </>

--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -232,9 +232,7 @@ const TreeInfos: FC<{
               <div>
                 <BaselineGrid>
                   <span>{wateredCircle}</span>
-                  <SmallParagraph>
-                    Bewässerungen: {wateringsSum}l
-                  </SmallParagraph>
+                  <SmallParagraph>Gießungen: {wateringsSum}l</SmallParagraph>
                 </BaselineGrid>
               </div>
               <div>

--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -22,7 +22,6 @@ import SmallParagraph from '../../SmallParagraph';
 import { useAdoptingActions } from '../../../utils/hooks/useAdoptingActions';
 import { useCommunityData } from '../../../utils/hooks/useCommunityData';
 import { rainCircle, wateredCircle } from '../../StackedBarChart/TooltipLegend';
-
 const { treetypes } = content.sidebar;
 
 const Wrapper = styled.div`
@@ -157,8 +156,16 @@ const TreeInfos: FC<{
   const barChartDate = currentDate < todayAt3pm ? todayAt3pm : currentDate;
 
   const wateringsSum = useMemo(() => {
-    if (!waterings || waterings.length > 0) return 0;
-    return waterings.reduce((sum, current) => sum + current.amount, 0);
+    if (!waterings) return 0;
+    const last30DaysWaterings = waterings.filter(w => {
+      const msPerDay = 86400000;
+      const elapsedMs = new Date().getTime() - Date.parse(w.timestamp);
+      return elapsedMs / msPerDay < 30;
+    });
+    return last30DaysWaterings.reduce(
+      (sum, current) => sum + current.amount,
+      0
+    );
   }, [waterings]);
 
   const rainSum = useMemo(() => {

--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -22,6 +22,7 @@ import SmallParagraph from '../../SmallParagraph';
 import { useAdoptingActions } from '../../../utils/hooks/useAdoptingActions';
 import { useCommunityData } from '../../../utils/hooks/useCommunityData';
 import { rainCircle, wateredCircle } from '../../StackedBarChart/TooltipLegend';
+
 const { treetypes } = content.sidebar;
 
 const Wrapper = styled.div`
@@ -160,7 +161,7 @@ const TreeInfos: FC<{
     const last30DaysWaterings = waterings.filter(w => {
       const msPerDay = 86400000;
       const elapsedMs = new Date().getTime() - Date.parse(w.timestamp);
-      return elapsedMs / msPerDay < 30;
+      return elapsedMs / msPerDay <= 30;
     });
     return last30DaysWaterings.reduce(
       (sum, current) => sum + current.amount,

--- a/src/components/Sidebar/SidebarTree/TreeInfos.tsx
+++ b/src/components/Sidebar/SidebarTree/TreeInfos.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useMemo } from 'react';
 import styled from 'styled-components';
 import { getWaterNeedByAge } from '../../../utils/getWaterNeedByAge';
 
@@ -21,6 +21,7 @@ import ButtonRound from '../../ButtonRound';
 import SmallParagraph from '../../SmallParagraph';
 import { useAdoptingActions } from '../../../utils/hooks/useAdoptingActions';
 import { useCommunityData } from '../../../utils/hooks/useCommunityData';
+import { rainCircle, wateredCircle } from '../../StackedBarChart/TooltipLegend';
 
 const { treetypes } = content.sidebar;
 
@@ -103,6 +104,13 @@ const ActionsWrapper = styled.div`
   padding-top: ${p => p.theme.spacingM};
 `;
 
+const BaselineGrid = styled.span`
+  display: inline-grid;
+  grid-auto-flow: column;
+  align-items: baseline;
+  column-gap: 4px;
+`;
+
 const TreeInfos: FC<{
   selectedTreeData: SelectedTreeType;
 }> = ({ selectedTreeData }) => {
@@ -147,6 +155,16 @@ const TreeInfos: FC<{
     We force the bar chart date to be 15:00 today, so that the new timestamped waterings (which are all at 15:00) will be displayed immediately. After 15:00 we can use the current time again.
   */
   const barChartDate = currentDate < todayAt3pm ? todayAt3pm : currentDate;
+
+  const wateringsSum = useMemo(() => {
+    if (!waterings || waterings.length > 0) return 0;
+    return waterings.reduce((sum, current) => sum + current.amount, 0);
+  }, [waterings]);
+
+  const rainSum = useMemo(() => {
+    const last30Days = selectedTreeData.radolan_days.slice(-30);
+    return last30Days.reduce((sum, current) => sum + current, 0);
+  }, [selectedTreeData.radolan_days]);
 
   return (
     <Wrapper>
@@ -211,6 +229,20 @@ const TreeInfos: FC<{
             <>
               <div>Wassermenge</div>
               <SmallParagraph>der letzten 30 Tage</SmallParagraph>
+              <div>
+                <BaselineGrid>
+                  <span>{wateredCircle}</span>
+                  <SmallParagraph>
+                    Bewässerungen: {wateringsSum}l
+                  </SmallParagraph>
+                </BaselineGrid>
+              </div>
+              <div>
+                <BaselineGrid>
+                  <span>{rainCircle}</span>
+                  <SmallParagraph>Regen: {rainSum}l</SmallParagraph>
+                </BaselineGrid>
+              </div>
             </>
           }
           isExpanded


### PR DESCRIPTION
Not sure if we want to implement this more sophisticated. This was a rather straight-forward approach. Hope I understood the `waterings` and `radolon_days` correctly. 

As requested in https://github.com/technologiestiftung/giessdenkiez-de/issues/475

As documented in https://app.asana.com/0/1204152181784036/1204994173851095

# "Wassermenge" Uncollapsed
![Bildschirmfoto 2023-07-13 um 15 32 11](https://github.com/technologiestiftung/giessdenkiez-de/assets/10830180/60299ed9-7ddc-4d50-ba88-ff64fc4c931a)

# "Wassermenge" Collapsed 
![Bildschirmfoto 2023-07-13 um 15 32 15](https://github.com/technologiestiftung/giessdenkiez-de/assets/10830180/688443fb-9a11-4369-9f0b-a737a3fc054e)

