### PR TITLE
fix(osm): Fix link to mapcomplete tool

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,11 +13,9 @@ NEXT_PUBLIC_MAPBOX_API_KEY=pk.123.xyz
 NEXT_PUBLIC_MAPBOX_TREES_TILESET_URL=mapbox://{username}.{tilesetId}
 NEXT_PUBLIC_MAPBOX_TREES_TILESET_LAYER={layer-name-within-tileset}
 
-# Weather data source
-NEXT_PUBLIC_RAIN_DATA_URL=https://tsb-trees.s3.eu-central-1.amazonaws.com/weather_light.geojson.gz
-
 # Asset sources
 NEXT_PUBLIC_PUMPS_DATA_URL=https://{Supabase_project_id}.supabase.co/storage/v1/object/public/{Supabase_bucket_name}/pumps.geojson
+# Weather data source
 NEXT_PUBLIC_RAIN_DATA_URL=https://{Supabase_project_id}.supabase.co/storage/v1/object/public/{Supabase_bucket_name}/weather_light.geojson
 
 # Map variables

--- a/src/components/TreesMap/TreesMap.tsx
+++ b/src/components/TreesMap/TreesMap.tsx
@@ -122,10 +122,13 @@ if (
   `);
 }
 
-const initialLatitude = +process.env.NEXT_PUBLIC_MAP_INITIAL_LATITUDE || 52.500869;
-const initialLongitude = +process.env.NEXT_PUBLIC_MAP_INITIAL_LONGITUDE || 13.419047;
+const initialLatitude =
+  +process.env.NEXT_PUBLIC_MAP_INITIAL_LATITUDE || 52.500869;
+const initialLongitude =
+  +process.env.NEXT_PUBLIC_MAP_INITIAL_LONGITUDE || 13.419047;
 const initialZoom = +process.env.NEXT_PUBLIC_MAP_INITIAL_ZOOM || 11;
-const initialZoomMobile = +process.env.NEXT_PUBLIC_MAP_INITIAL_ZOOM_MOBILE || 13;
+const initialZoomMobile =
+  +process.env.NEXT_PUBLIC_MAP_INITIAL_ZOOM_MOBILE || 13;
 
 const defaultViewport = {
   latitude: initialLatitude,
@@ -603,7 +606,7 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(function TreesMap(
               ? {
                   '': (
                     <StyledTextLink
-                      href={getOSMEditorURL(pumpInfo.id)}
+                      href={getOSMEditorURL({ nodeId: pumpInfo.id })}
                       target='_blank'
                       rel='noreferrer nofollow'
                     >

--- a/src/components/TreesMap/TreesMap.tsx
+++ b/src/components/TreesMap/TreesMap.tsx
@@ -97,6 +97,8 @@ interface PumpPropertiesType {
   status: string;
   check_date: string;
   style: string;
+  lat: number;
+  lon: number;
 }
 
 interface PumpTooltipType extends PumpPropertiesType {
@@ -606,7 +608,11 @@ export const TreesMap = forwardRef<MapRef, TreesMapPropsType>(function TreesMap(
               ? {
                   '': (
                     <StyledTextLink
-                      href={getOSMEditorURL({ nodeId: pumpInfo.id })}
+                      href={getOSMEditorURL({
+                        nodeId: pumpInfo.id,
+                        lat: pumpInfo.lat,
+                        lon: pumpInfo.lon,
+                      })}
                       target='_blank'
                       rel='noreferrer nofollow'
                     >

--- a/src/components/TreesMap/osmUtil.ts
+++ b/src/components/TreesMap/osmUtil.ts
@@ -1,9 +1,9 @@
 export const getOSMEditorURL = (nodeId: number): string => {
-  const mapcompleteUrl = 'https://mapcomplete.osm.be/theme';
+  const mapcompleteUrl = 'https://mapcomplete.org';
   const params = new URLSearchParams();
   params.set(
     'userlayout',
-    'https://tordans.github.io/MapComplete-ThemeHelper/OSM-Berlin-Themes/man_made-walter_well-status-checker/theme.json'
+    'https://raw.githubusercontent.com/technologiestiftung/MapComplete-ThemeHelper/024ef9134987e0ead34f261a6270d5572c4d31a4/OSM-Berlin-Themes/man_made-walter_well-status-checker/theme.json'
   );
   params.set('language', 'de');
   const selectedPump = `#node/${nodeId}`;

--- a/src/components/TreesMap/osmUtil.ts
+++ b/src/components/TreesMap/osmUtil.ts
@@ -16,9 +16,8 @@ export const getOSMEditorURL = ({
     'https://raw.githubusercontent.com/technologiestiftung/MapComplete-ThemeHelper/024ef9134987e0ead34f261a6270d5572c4d31a4/OSM-Berlin-Themes/man_made-walter_well-status-checker/theme.json'
   );
 
-  if (zoom) {
-    params.set('z', `${zoom}`);
-  }
+  params.set('z', `${zoom ? zoom : 18}`);
+
   if (lat && lon) {
     params.set('lat', `${lat}`);
     params.set('lon', `${lon}`);

--- a/src/components/TreesMap/osmUtil.ts
+++ b/src/components/TreesMap/osmUtil.ts
@@ -1,10 +1,29 @@
-export const getOSMEditorURL = (nodeId: number): string => {
+export const getOSMEditorURL = ({
+  nodeId,
+  zoom,
+  lat,
+  lon,
+}: {
+  nodeId: number;
+  zoom?: number;
+  lat?: number;
+  lon?: number;
+}): string => {
   const mapcompleteUrl = 'https://mapcomplete.org';
   const params = new URLSearchParams();
   params.set(
     'userlayout',
     'https://raw.githubusercontent.com/technologiestiftung/MapComplete-ThemeHelper/024ef9134987e0ead34f261a6270d5572c4d31a4/OSM-Berlin-Themes/man_made-walter_well-status-checker/theme.json'
   );
+
+  if (zoom) {
+    params.set('z', `${zoom}`);
+  }
+  if (lat && lon) {
+    params.set('lat', `${lat}`);
+    params.set('lon', `${lon}`);
+  }
+
   params.set('language', 'de');
   const selectedPump = `#node/${nodeId}`;
   return `${mapcompleteUrl}?${params.toString()}${selectedPump}`;

--- a/src/components/TreesMap/pumpsUtils.ts
+++ b/src/components/TreesMap/pumpsUtils.ts
@@ -2,6 +2,9 @@ export interface PumpEventInfoType {
   x: number;
   y: number;
   object?: {
+    geometry: {
+      coordinates: [number, number];
+    };
     properties?:
       | {
           id: number;
@@ -22,6 +25,8 @@ interface ParsedPumpInfoType {
   style: string;
   x: number;
   y: number;
+  lat: number;
+  lon: number;
 }
 
 export const pumpEventInfoToState = (
@@ -29,6 +34,8 @@ export const pumpEventInfoToState = (
 ): ParsedPumpInfoType | null => {
   if (info && info.object && info.object.properties) {
     return {
+      lat: info.object.geometry.coordinates[1],
+      lon: info.object.geometry.coordinates[0],
       id: info.object.properties.id,
       address: info.object.properties['addr:full'] || '',
       check_date: info.object.properties['check_date'] || '',


### PR DESCRIPTION
We are linking to a version of the theme in our account
and we are using a raw github url with a git hash now

Todos:

- [x] Can we pass zoom?
- [x] Can we pass the location?

Yes we can.

- [x] Get lat lon of pump
- [x] Pass zoom
