### PR TITLE
Fix URL to edit Strassenbrunnen in OSM

### DIFF
--- a/src/components/TreesMap/osmUtil.ts
+++ b/src/components/TreesMap/osmUtil.ts
@@ -1,5 +1,5 @@
 export const getOSMEditorURL = (nodeId: number): string => {
-  const mapcompleteUrl = 'https://mapcomplete.osm.be/theme';
+  const mapcompleteUrl = 'https://mapcomplete.org/theme';
   const params = new URLSearchParams();
   params.set(
     'userlayout',


### PR DESCRIPTION
Mapcomplete updated it's URL but there is no full redirect ([yet](https://github.com/pietervdvn/MapComplete/issues/1560)).

It would be great if this update could go live soon since those URLs are broken ATM.

---

Ping https://github.com/tordans/MapComplete-ThemeHelper/issues/2