### PR TITLE
chore: update DWD harvester to 2.1.1

### DIFF
--- a/.github/workflows/rain.yml
+++ b/.github/workflows/rain.yml
@@ -14,7 +14,7 @@ jobs:
     name: Aggregate rain data from DWD radolan
     steps:
       - name: Harvester
-        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@v2.1.1
+        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@v2.1.1-rc.1
         id: harvester
         with:
           PG_SERVER: ${{ secrets.PG_SERVER }}

--- a/.github/workflows/rain.yml
+++ b/.github/workflows/rain.yml
@@ -14,7 +14,7 @@ jobs:
     name: Aggregate rain data from DWD radolan
     steps:
       - name: Harvester
-        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@v2.1.0
+        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@v2.1.1
         id: harvester
         with:
           PG_SERVER: ${{ secrets.PG_SERVER }}
@@ -31,3 +31,4 @@ jobs:
           MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
           MAPBOXTILESET: ${{ secrets.MAPBOXTILESET }}
           MAPBOXLAYERNAME: ${{ secrets.MAPBOXLAYERNAME }}
+          SKIP_MAPBOX: 'False'

--- a/.github/workflows/rain.yml
+++ b/.github/workflows/rain.yml
@@ -14,7 +14,7 @@ jobs:
     name: Aggregate rain data from DWD radolan
     steps:
       - name: Harvester
-        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@v2.1.1-rc.1
+        uses: technologiestiftung/giessdenkiez-de-dwd-harvester@${{ vars.DWD_HARVESTER_VERSION }}
         id: harvester
         with:
           PG_SERVER: ${{ secrets.PG_SERVER }}


### PR DESCRIPTION
Waiting for https://github.com/technologiestiftung/giessdenkiez-de-dwd-harvester/pull/105 to be merged and released first

new env var: `DWD_HARVESTER_VERSION` needs to be set in each environment (i did this already)