### PR TITLE
feat/signup set username

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "deck.gl": "8.9.34",
         "focus-trap-react": "10.2.2",
         "history": "4.10.1",
+        "lodash.debounce": "4.0.8",
         "mapbox-gl": "3.1.0",
         "next": "14.1.0",
         "rc-slider": "9.7.5",
@@ -20702,8 +20703,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "deck.gl": "8.9.34",
     "focus-trap-react": "10.2.2",
     "history": "4.10.1",
+    "lodash.debounce": "4.0.8",
     "mapbox-gl": "3.1.0",
     "next": "14.1.0",
     "rc-slider": "9.7.5",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -130,6 +130,7 @@ export interface FeatureType {
 export interface CredentialsData {
   email: string;
   password: string;
+  username?: string;
 }
 export interface ResetCredentialsData extends CredentialsData {
   repeatPassword: string;

--- a/src/components/Forms/Buttons/ButtonSubmitRound.tsx
+++ b/src/components/Forms/Buttons/ButtonSubmitRound.tsx
@@ -74,6 +74,7 @@ const ButtonSubmitRound: FC<{
   fontSize?: string;
   margin?: string;
   disabled?: boolean;
+  children: React.ReactNode;
 }> = ({
   type = 'submit',
   colorType = 'primary',

--- a/src/components/Forms/CredentialsForm/index.tsx
+++ b/src/components/Forms/CredentialsForm/index.tsx
@@ -5,6 +5,8 @@ import ButtonSubmitRound from '../Buttons/ButtonSubmitRound';
 import { StyledFormTextInput } from '../Inputs';
 import { StyledLabel } from '../Labels';
 import { PasswordValidation } from '../PasswordValidation';
+import { UsernameValidation } from '../UsernameValidation';
+import { UsernamePattern } from '../../../utils/validateUsername';
 
 export const CredentialsForm = ({
   formData,
@@ -13,13 +15,19 @@ export const CredentialsForm = ({
   buttonText,
   isRecovery,
   isSignIn,
+  handleEmailInputBlur,
+  usernamePatterns,
 }: {
   formData: CredentialsData;
-  handleInputChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleInputChange: (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => Promise<void>;
   handleSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  handleEmailInputBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   buttonText: string;
   isRecovery?: boolean;
   isSignIn?: boolean;
+  usernamePatterns?: UsernamePattern;
 }) => {
   return (
     <>
@@ -37,10 +45,29 @@ export const CredentialsForm = ({
             type='email'
             name='email'
             required
-            onChange={handleInputChange}
+            onChange={e => handleInputChange(e).catch(console.error)}
             value={formData.email}
+            // onBlur={handleEmailInputBlur}
           ></StyledFormTextInput>
         </StyledFormRow>
+        {!isSignIn && !isRecovery && (
+          <StyledFormRow>
+            <StyledLabel htmlFor='username'>
+              <>Benutzername</>
+            </StyledLabel>
+            <StyledFormTextInput
+              id='username'
+              type='username'
+              name='username'
+              required
+              onChange={handleInputChange}
+              value={formData.username}
+            ></StyledFormTextInput>
+            {usernamePatterns && (
+              <UsernameValidation patterns={usernamePatterns} />
+            )}
+          </StyledFormRow>
+        )}
         {!isRecovery && (
           <StyledFormRow>
             <StyledLabel htmlFor='password'>
@@ -56,7 +83,7 @@ export const CredentialsForm = ({
               onChange={handleInputChange}
               value={formData.password}
             ></StyledFormTextInput>
-            {!isSignIn && (<PasswordValidation password={formData.password} />) }
+            {!isSignIn && <PasswordValidation password={formData.password} />}
           </StyledFormRow>
         )}
         <StyledFormRow>

--- a/src/components/Forms/CredentialsForm/index.tsx
+++ b/src/components/Forms/CredentialsForm/index.tsx
@@ -15,7 +15,7 @@ export const CredentialsForm = ({
   buttonText,
   isRecovery,
   isSignIn,
-  handleEmailInputBlur,
+
   usernamePatterns,
 }: {
   formData: CredentialsData;
@@ -47,7 +47,6 @@ export const CredentialsForm = ({
             required
             onChange={e => handleInputChange(e).catch(console.error)}
             value={formData.email}
-            // onBlur={handleEmailInputBlur}
           ></StyledFormTextInput>
         </StyledFormRow>
         {!isSignIn && !isRecovery && (

--- a/src/components/Forms/PasswordValidation/index.tsx
+++ b/src/components/Forms/PasswordValidation/index.tsx
@@ -1,22 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
 import {
   PasswordPattern,
   specialCharacters,
   validatePassword,
 } from '../../../utils/validatePassword';
 import SmallParagraph from '../../SmallParagraph';
-
-interface StyledSpanProps {
-  success: boolean;
-}
-const StyledSpan = styled.span<StyledSpanProps>`
-  color: ${p => (p.success ? p.theme.colorPrimary : p.theme.colorAlarm)};
-`;
-
-const ValidorNot = ({ success }: { success: boolean }) => {
-  return <StyledSpan success={success}>{success ? '✓' : '☓'}</StyledSpan>;
-};
+import { ValidOrNot } from '../ValidOrNot';
 
 export const PasswordValidation = ({ password }: { password: string }) => {
   const [errors, setErrors] = useState<PasswordPattern>({
@@ -36,11 +25,11 @@ export const PasswordValidation = ({ password }: { password: string }) => {
     <>
       <SmallParagraph>
         Dein Passwort sollte: Mindestens 8 Zeichen lang sein{' '}
-        <ValidorNot success={errors.length} />, Klein- und Großbuchstaben{' '}
-        <ValidorNot success={errors.lowerCase && errors.upperCase} />,
+        <ValidOrNot success={errors.length} />, Klein- und Großbuchstaben{' '}
+        <ValidOrNot success={errors.lowerCase && errors.upperCase} />,
         mindestens eines dieser Sonderzeichen <code>{specialCharacters}</code>{' '}
-        <ValidorNot success={errors.specialChar} /> und Zahlen{' '}
-        <ValidorNot success={errors.digit} /> enthalten.
+        <ValidOrNot success={errors.specialChar} /> und Zahlen{' '}
+        <ValidOrNot success={errors.digit} /> enthalten.
       </SmallParagraph>
     </>
   );

--- a/src/components/Forms/UsernameValidation/index.tsx
+++ b/src/components/Forms/UsernameValidation/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import SmallParagraph from '../../SmallParagraph';
 import { ValidOrNot } from '../ValidOrNot';
 import { UsernamePattern } from '../../../utils/validateUsername';
@@ -8,26 +8,15 @@ export const UsernameValidation = ({
 }: {
   patterns: UsernamePattern;
 }) => {
-  const [errors, setErrors] = useState<UsernamePattern>({
-    minLength: false,
-    maxLength: false,
-    allowedCharacters: false,
-    notTaken: false,
-  });
-
-  useEffect(() => {
-    setErrors(patterns);
-  }, [patterns]);
-
   return (
     <>
       <SmallParagraph>
         Dein Benutzername sollte zwischen 3{' '}
-        <ValidOrNot success={errors.minLength} /> und 50{' '}
-        <ValidOrNot success={errors.maxLength} /> Zeichen lang sein, nur aus
+        <ValidOrNot success={patterns.minLength} /> und 50{' '}
+        <ValidOrNot success={patterns.maxLength} /> Zeichen lang sein, nur aus
         Zeichen und Zahlen (ohne Leerzeichen am Anfang und Ende){' '}
-        <ValidOrNot success={errors.allowedCharacters} /> bestehen und naturlich
-        nicht vergeben sein <ValidOrNot success={errors.notTaken} />
+        <ValidOrNot success={patterns.allowedCharacters} /> bestehen und
+        naturlich nicht vergeben sein <ValidOrNot success={patterns.notTaken} />
       </SmallParagraph>
     </>
   );

--- a/src/components/Forms/UsernameValidation/index.tsx
+++ b/src/components/Forms/UsernameValidation/index.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import SmallParagraph from '../../SmallParagraph';
+import { ValidOrNot } from '../ValidOrNot';
+import { UsernamePattern } from '../../../utils/validateUsername';
+
+export const UsernameValidation = ({
+  patterns,
+}: {
+  patterns: UsernamePattern;
+}) => {
+  const [errors, setErrors] = useState<UsernamePattern>({
+    minLength: false,
+    maxLength: false,
+    allowedCharacters: false,
+    notTaken: false,
+  });
+
+  useEffect(() => {
+    setErrors(patterns);
+  }, [patterns]);
+
+  return (
+    <>
+      <SmallParagraph>
+        Dein Benutzername sollte zwischen 3{' '}
+        <ValidOrNot success={errors.minLength} /> und 50{' '}
+        <ValidOrNot success={errors.maxLength} /> Zeichen lang sein, nur aus
+        Zeichen und Zahlen (ohne Leerzeichen am Anfang und Ende){' '}
+        <ValidOrNot success={errors.allowedCharacters} /> bestehen und naturlich
+        nicht vergeben sein <ValidOrNot success={errors.notTaken} />
+      </SmallParagraph>
+    </>
+  );
+};

--- a/src/components/Forms/UsernameValidation/index.tsx
+++ b/src/components/Forms/UsernameValidation/index.tsx
@@ -16,7 +16,8 @@ export const UsernameValidation = ({
         <ValidOrNot success={patterns.maxLength} /> Zeichen lang sein, nur aus
         Zeichen und Zahlen (ohne Leerzeichen am Anfang und Ende){' '}
         <ValidOrNot success={patterns.allowedCharacters} /> bestehen und
-        naturlich nicht vergeben sein <ValidOrNot success={patterns.notTaken} />
+        natürlich nicht vergeben sein <ValidOrNot success={patterns.notTaken} />
+        .
       </SmallParagraph>
     </>
   );

--- a/src/components/Forms/ValidOrNot/index.tsx
+++ b/src/components/Forms/ValidOrNot/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface StyledSpanProps {
+  success: boolean;
+}
+
+const StyledSpan = styled.span<StyledSpanProps>`
+  color: ${p => (p.success ? p.theme.colorPrimary : p.theme.colorAlarm)};
+`;
+
+export const ValidOrNot = ({ success }: { success: boolean }) => {
+  return <StyledSpan success={success}>{success ? '✓' : '☓'}</StyledSpan>;
+};

--- a/src/components/Paragraph/index.tsx
+++ b/src/components/Paragraph/index.tsx
@@ -17,11 +17,11 @@ const ParagraphContainer = styled.p`
   }
 `;
 
-const Paragraph: FC<{ className?: string; onClick?: () => void }> = ({
-  children,
-  className = '',
-  onClick = () => undefined,
-}) =>
+const Paragraph: FC<{
+  children: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+}> = ({ children, className = '', onClick = () => undefined }) =>
   typeof children === 'string' ? (
     <ParagraphContainer
       className={className}

--- a/src/components/Quotes/index.tsx
+++ b/src/components/Quotes/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 /**
  * Use typografically correct quotes for german
  */
-export const Quotes: React.FC = ({ children }) => {
+export const Quotes: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
   return <span>&bdquo;{children}&ldquo;</span>;
 };

--- a/src/components/Sidebar/SidebarAuth/SidebarAuth.test.tsx
+++ b/src/components/Sidebar/SidebarAuth/SidebarAuth.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { describe, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { SidebarAuth } from './index';
 
+import { SidebarAuth } from './';
 describe('component SidebarAuth', () => {
   test('should render view sigin', () => {
     render(
@@ -12,6 +13,7 @@ describe('component SidebarAuth', () => {
         isLoading={false}
       />
     );
+
     expect(screen.getByText(/Anmelden/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/E-Mail/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/passwort/i)).toBeInTheDocument();
@@ -34,6 +36,7 @@ describe('component SidebarAuth', () => {
     expect(button).toBeInTheDocument();
     expect(screen.getByLabelText(/E-Mail/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/passwort/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/benutzername/i)).toBeInTheDocument();
     expect(screen.getByText(/Log dich ein/i)).toBeInTheDocument();
     expect(screen.getByText(/Passwort vergessen\?/i)).toBeInTheDocument();
   });

--- a/src/components/Sidebar/SidebarAuth/index.tsx
+++ b/src/components/Sidebar/SidebarAuth/index.tsx
@@ -1,5 +1,5 @@
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { AuthView } from '../../../../pages/auth';
 import SidebarTitle from '../SidebarTitle';
 import { UserNotificationObjectType } from '../../Notification';
@@ -11,11 +11,11 @@ import { SidebarLoading } from '../SidebarLoading';
 import styled from 'styled-components';
 import Paragraph from '../../Paragraph';
 import { Quotes } from '../../Quotes';
-import debounce from 'lodash/debounce';
 import {
   UsernamePattern,
   validateUsername,
 } from '../../../utils/validateUsername';
+import debounce from 'lodash/debounce';
 
 enum titles {
   signin = 'Anmelden',
@@ -66,42 +66,6 @@ export const SidebarAuth = ({
     });
   };
 
-  const checkIfUsernameIsNotTaken = debounce(
-    async (
-      username: string,
-      setNotification: React.Dispatch<
-        React.SetStateAction<UserNotificationObjectType | null>
-      >,
-      setUsernamePattern: React.Dispatch<React.SetStateAction<UsernamePattern>>
-    ): Promise<void> => {
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('username')
-        .eq('username', username);
-      if (error) {
-        console.error(error);
-        return;
-      }
-      if (data) {
-        if (data.length > 0) {
-          setNotification({
-            message: 'Benutzername bereits vergeben',
-            type: 'error',
-          });
-          setUsernamePattern(up => {
-            return { ...up, notTaken: false };
-          });
-        } else {
-          setUsernamePattern(up => {
-            return { ...up, notTaken: true };
-          });
-        }
-      } else {
-        throw new Error('could not check username');
-      }
-    },
-    500
-  );
   const handleSignInSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -270,18 +234,42 @@ export const SidebarAuth = ({
     }
   };
 
-  useEffect(() => {
-    if (formData.username === '') {
-      setUsernamePatterns({
-        ...usernamePatterns,
-        notTaken: false,
-        minLength: false,
-        maxLength: false,
-
-        allowedCharacters: false,
-      });
-    }
-  }, [usernamePatterns, formData.username]);
+  const checkIfUsernameIsNotTaken = debounce(
+    async (
+      username: string,
+      setNotification: React.Dispatch<
+        React.SetStateAction<UserNotificationObjectType | null>
+      >,
+      setUsernamePattern: React.Dispatch<React.SetStateAction<UsernamePattern>>
+    ): Promise<void> => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('username')
+        .eq('username', username);
+      if (error) {
+        console.error(error);
+        return;
+      }
+      if (data) {
+        if (data.length > 0) {
+          setNotification({
+            message: 'Benutzername bereits vergeben',
+            type: 'error',
+          });
+          setUsernamePattern(up => {
+            return { ...up, notTaken: false };
+          });
+        } else {
+          setUsernamePattern(up => {
+            return { ...up, notTaken: true };
+          });
+        }
+      } else {
+        throw new Error('could not check username');
+      }
+    },
+    500
+  );
 
   switch (view) {
     case 'signin': {

--- a/src/components/Sidebar/SidebarAuth/index.tsx
+++ b/src/components/Sidebar/SidebarAuth/index.tsx
@@ -1,5 +1,5 @@
 import { useSupabaseClient } from '@supabase/auth-helpers-react';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AuthView } from '../../../../pages/auth';
 import SidebarTitle from '../SidebarTitle';
 import { UserNotificationObjectType } from '../../Notification';
@@ -10,7 +10,12 @@ import { CredentialsForm } from '../../Forms/CredentialsForm';
 import { SidebarLoading } from '../SidebarLoading';
 import styled from 'styled-components';
 import Paragraph from '../../Paragraph';
-import { Quotes, quotesTag } from '../../Quotes';
+import { Quotes } from '../../Quotes';
+import debounce from 'lodash/debounce';
+import {
+  UsernamePattern,
+  validateUsername,
+} from '../../../utils/validateUsername';
 
 enum titles {
   signin = 'Anmelden',
@@ -43,15 +48,60 @@ export const SidebarAuth = ({
   const [formData, setFormData] = useState<CredentialsData>({
     email: '',
     password: '',
+    username: '',
+  });
+
+  const [usernamePatterns, setUsernamePatterns] = useState<UsernamePattern>({
+    minLength: false,
+    maxLength: false,
+    notTaken: false,
+    allowedCharacters: false,
   });
 
   const clearFields = () => {
     setFormData({
       email: '',
       password: '',
+      username: '',
     });
   };
 
+  const checkIfUsernameIsNotTaken = debounce(
+    async (
+      username: string,
+      setNotification: React.Dispatch<
+        React.SetStateAction<UserNotificationObjectType | null>
+      >,
+      setUsernamePattern: React.Dispatch<React.SetStateAction<UsernamePattern>>
+    ): Promise<void> => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('username')
+        .eq('username', username);
+      if (error) {
+        console.error(error);
+        return;
+      }
+      if (data) {
+        if (data.length > 0) {
+          setNotification({
+            message: 'Benutzername bereits vergeben',
+            type: 'error',
+          });
+          setUsernamePattern(up => {
+            return { ...up, notTaken: false };
+          });
+        } else {
+          setUsernamePattern(up => {
+            return { ...up, notTaken: true };
+          });
+        }
+      } else {
+        throw new Error('could not check username');
+      }
+    },
+    500
+  );
   const handleSignInSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -64,13 +114,15 @@ export const SidebarAuth = ({
   };
   const handleSignUpSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    signUp(formData.email, formData.password).catch(error => {
-      console.error(error);
-      setNotification({
-        message: error.message,
-        type: 'error',
-      });
-    });
+    signUp(formData.email, formData.password, formData.username).catch(
+      error => {
+        console.error(error);
+        setNotification({
+          message: error.message,
+          type: 'error',
+        });
+      }
+    );
   };
 
   const handleRecoverySubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -85,23 +137,56 @@ export const SidebarAuth = ({
     clearFields();
   };
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = async (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const { name, value } = event.target;
+    if (name === 'username') {
+      // make a throttled request to the api to check if the username is available
+      // if not, show a message
+      const { patterns } = validateUsername(value);
+      setUsernamePatterns(patterns);
+      await checkIfUsernameIsNotTaken(
+        value,
+        setNotification,
+        setUsernamePatterns
+      );
+    }
     setNotification(null);
-
     setFormData({
       ...formData,
       [name]: value,
     });
   };
+  const handleEmailInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    console.log(event.target);
+    const { name, value } = event.target;
+    if (name === 'email' && formData.username === '') {
+      setFormData(fd => {
+        return { ...fd, username: value.split('@')[0] };
+      });
+    }
+  };
 
   let form: JSX.Element | null = null;
   let linkText: JSX.Element | null = null;
 
-  const signUp = async (email: string, password: string) => {
+  const signUp = async (email: string, password: string, username?: string) => {
+    if (Object.values(usernamePatterns).every(Boolean) === false) {
+      setNotification({
+        message: 'Bitte überprüfe deinen Benutzernamen',
+        type: 'error',
+      });
+      return;
+    }
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        data: {
+          signup_username: username,
+        },
+      },
     });
     if (error) {
       if (error.message.includes('User already registered')) {
@@ -185,6 +270,19 @@ export const SidebarAuth = ({
     }
   };
 
+  useEffect(() => {
+    if (formData.username === '') {
+      setUsernamePatterns({
+        ...usernamePatterns,
+        notTaken: false,
+        minLength: false,
+        maxLength: false,
+
+        allowedCharacters: false,
+      });
+    }
+  }, [usernamePatterns, formData.username]);
+
   switch (view) {
     case 'signin': {
       form = (
@@ -211,7 +309,9 @@ export const SidebarAuth = ({
           formData={formData}
           handleInputChange={handleInputChange}
           handleSubmit={handleSignUpSubmit}
+          handleEmailInputBlur={handleEmailInputBlur}
           buttonText='Registrieren'
+          usernamePatterns={usernamePatterns}
           isSignIn={false}
         />
       );

--- a/src/components/Sidebar/SidebarAuth/index.tsx
+++ b/src/components/Sidebar/SidebarAuth/index.tsx
@@ -122,15 +122,6 @@ export const SidebarAuth = ({
       [name]: value,
     });
   };
-  const handleEmailInputBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    console.log(event.target);
-    const { name, value } = event.target;
-    if (name === 'email' && formData.username === '') {
-      setFormData(fd => {
-        return { ...fd, username: value.split('@')[0] };
-      });
-    }
-  };
 
   let form: JSX.Element | null = null;
   let linkText: JSX.Element | null = null;
@@ -297,7 +288,6 @@ export const SidebarAuth = ({
           formData={formData}
           handleInputChange={handleInputChange}
           handleSubmit={handleSignUpSubmit}
-          handleEmailInputBlur={handleEmailInputBlur}
           buttonText='Registrieren'
           usernamePatterns={usernamePatterns}
           isSignIn={false}

--- a/src/components/SmallParagraph/index.tsx
+++ b/src/components/SmallParagraph/index.tsx
@@ -20,11 +20,11 @@ const SmallParagraphContainer = styled.p`
   }
 `;
 
-const SmallParagraph: FC<{ className?: string; onClick?: () => void }> = ({
-  children,
-  className = '',
-  onClick = () => undefined,
-}) =>
+const SmallParagraph: FC<{
+  className?: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+}> = ({ children, className = '', onClick = () => undefined }) =>
   typeof children === 'string' ? (
     <SmallParagraphContainer
       className={className}

--- a/src/utils/validateUsername.test.ts
+++ b/src/utils/validateUsername.test.ts
@@ -1,0 +1,45 @@
+import { validateUsername } from './validateUsername';
+
+describe('Username validation', () => {
+  test('Validates username with minimum criteria', () => {
+    const username = 'abc';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(true);
+  });
+  test('Validates username with maximim criteria', () => {
+    const username = 'abcdefghijklmnopqrstabcdefghijklmnopqrst1234567890';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(true);
+  });
+
+  test('Rejects username with fewer than 3 characters', () => {
+    const username = 'ab';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(false);
+  });
+
+  test('Rejects username with more than 50 characters', () => {
+    const username = 'abcdefghijklmnopqrstabcdefghijklmnopqrst12345678901';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(false);
+  });
+
+  test('Rejects username with special characters', () => {
+    const username = 'abc@';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(false);
+  });
+
+  test('Allow username with spaces', () => {
+    const username = 'abc def';
+    const { usernameIsValid } = validateUsername(username);
+    expect(usernameIsValid).toBe(true);
+  });
+
+  test.todo('Rejects username is taken');
+  // test('Rejects username is taken', () => {
+  //   const username = 'abc';
+  //   const { usernameIsValid } = validateUsername(username);
+  //   expect(usernameIsValid).toBe(false);
+  // });
+});

--- a/src/utils/validateUsername.test.ts
+++ b/src/utils/validateUsername.test.ts
@@ -35,11 +35,4 @@ describe('Username validation', () => {
     const { usernameIsValid } = validateUsername(username);
     expect(usernameIsValid).toBe(true);
   });
-
-  test.todo('Rejects username is taken');
-  // test('Rejects username is taken', () => {
-  //   const username = 'abc';
-  //   const { usernameIsValid } = validateUsername(username);
-  //   expect(usernameIsValid).toBe(false);
-  // });
 });

--- a/src/utils/validateUsername.ts
+++ b/src/utils/validateUsername.ts
@@ -1,0 +1,19 @@
+export interface UsernamePattern {
+  minLength: boolean;
+  maxLength: boolean;
+  allowedCharacters: boolean;
+  notTaken: boolean;
+}
+
+export function validateUsername(
+  username: string
+): { usernameIsValid: boolean; patterns: UsernamePattern } {
+  const patterns = {
+    minLength: username.length >= 3,
+    maxLength: username.length <= 50,
+    allowedCharacters: /^[a-zA-Z0-9]+(\s+[a-zA-Z0-9]+)*$/.test(username),
+    notTaken: true,
+  };
+
+  return { patterns, usernameIsValid: Object.values(patterns).every(Boolean) };
+}

--- a/test/vitest.setup.js
+++ b/test/vitest.setup.js
@@ -1,6 +1,6 @@
 // import 'whatwg-fetch';
 import '@testing-library/dom';
-import '@testing-library/jest-dom/vitest';
+import '@testing-library/jest-dom';
 import { server } from '../src/mocks/server';
 import ReactDOM from 'react-dom';
 


### PR DESCRIPTION
This PR adds a new username field to the signup form.

Validates against the rules username > 3 char, username < 50 char, only digits and characters with whitesapce in between. It also checks if the username already exists in `public.profiles`.

- feat(username): Set username during signup
- fix(types): React.FC types need children prop


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206271447147981