### PR TITLE
Feat/move notification further up

### DIFF
--- a/src/assets/content-types.tsx
+++ b/src/assets/content-types.tsx
@@ -35,6 +35,7 @@ interface PasswordRestrictions {
 }
 interface AuthErrors {
   checkUsername: string;
+  checkPassword: string;
   userExistsAlready: string;
   emailCouldNotBeSent: string;
   usernameOrPasswordWrong: string;

--- a/src/assets/content.tsx
+++ b/src/assets/content.tsx
@@ -352,6 +352,7 @@ const deContent: Content = {
     },
     errors: {
       checkUsername: 'Bitte überprüfe Deinen Benutzernamen',
+      checkPassword: 'Bitte überprüfe Dein Passwort',
       userExistsAlready: 'Benutzer bereits registriert',
       emailCouldNotBeSent:
         'Die E-Mail an "_1_" konnte nicht verschickt werden. Versuch es erneut.',
@@ -726,6 +727,7 @@ const enContent = {
     },
     errors: {
       checkUsername: 'Please check your username',
+      checkPassword: 'Please check your password',
       userExistsAlready: 'User already registered',
       emailCouldNotBeSent: 'Email to "_1_" could not be sent. Try again.',
       usernameOrPasswordWrong: 'Username or password are wrong',

--- a/src/components/Forms/AuthForm/index.tsx
+++ b/src/components/Forms/AuthForm/index.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSession, useSessionContext } from '@supabase/auth-helpers-react';
 import { SidebarAuth } from '../../Sidebar/SidebarAuth';
-import { StyledFlexContainer, StyledFormRow } from '../../Forms';
-import {
-  UserNotification,
-  UserNotificationObjectType,
-} from '../../Notification';
+import { UserNotificationObjectType } from '../../Notification';
 
 import { useRouter } from 'next/router';
 export type AuthView = 'signin' | 'signup' | 'recovery' | 'confirm';
@@ -44,18 +40,9 @@ function AuthForm() {
         isLoading={isLoading}
         view={view}
         setView={setView}
+        currentNotification={currentNotification}
         setNotification={setCurrentNotification}
       />
-      <StyledFlexContainer>
-        <StyledFormRow>
-          {currentNotification && (
-            <UserNotification
-              type={currentNotification.type}
-              message={currentNotification.message}
-            />
-          )}
-        </StyledFormRow>
-      </StyledFlexContainer>
     </div>
   );
 }

--- a/src/components/Forms/CredentialsForm/index.tsx
+++ b/src/components/Forms/CredentialsForm/index.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { StyledForm, StyledFormRow } from '..';
 import { CredentialsData } from '../../../common/interfaces';
 import { UsernamePattern } from '../../../utils/validateUsername';
-import { UserNotification } from '../../Notification';
+import {
+  UserNotification,
+  UserNotificationObjectType,
+} from '../../Notification';
 import ButtonSubmitRound from '../Buttons/ButtonSubmitRound';
 import { StyledFormTextInput } from '../Inputs';
 import { StyledLabel } from '../Labels';
@@ -19,6 +22,7 @@ export const CredentialsForm = ({
   isSignIn,
   usernamePatterns,
   isUsernameTaken,
+  currentNotification,
 }: {
   formData: CredentialsData;
   handleInputChange: (
@@ -31,6 +35,7 @@ export const CredentialsForm = ({
   isSignIn?: boolean;
   usernamePatterns?: UsernamePattern;
   isUsernameTaken?: boolean;
+  currentNotification: UserNotificationObjectType | null;
 }) => {
   const content = useLocalizedContent();
 
@@ -115,6 +120,14 @@ export const CredentialsForm = ({
         <StyledFormRow>
           <ButtonSubmitRound type='submit'>{buttonText}</ButtonSubmitRound>
         </StyledFormRow>
+        {currentNotification && (
+          <StyledFormRow>
+            <UserNotification
+              type={currentNotification.type}
+              message={currentNotification.message}
+            />
+          </StyledFormRow>
+        )}
       </StyledForm>
     </>
   );

--- a/src/components/Sidebar/SidebarAuth/index.tsx
+++ b/src/components/Sidebar/SidebarAuth/index.tsx
@@ -54,6 +54,7 @@ export const SidebarAuth = ({
 
   const {
     checkUsername,
+    checkPassword,
     userExistsAlready,
     emailCouldNotBeSent,
     usernameOrPasswordWrong,
@@ -159,7 +160,7 @@ export const SidebarAuth = ({
   const signUp = async ({ email, password, username }: CredentialsData) => {
     if (username === undefined) {
       setNotification({
-        message: 'Bitte überprüfe dein Benutzername',
+        message: checkUsername,
         type: 'error',
       });
       return;
@@ -169,7 +170,7 @@ export const SidebarAuth = ({
 
     if (!isUsernameValid) {
       setNotification({
-        message: 'Bitte überprüfe dein Benutzername',
+        message: checkUsername,
         type: 'error',
       });
       return;
@@ -179,7 +180,7 @@ export const SidebarAuth = ({
 
     if (!isPasswordValid) {
       setNotification({
-        message: checkUsername,
+        message: checkPassword,
         type: 'error',
       });
       return;

--- a/src/components/Sidebar/SidebarAuth/index.tsx
+++ b/src/components/Sidebar/SidebarAuth/index.tsx
@@ -27,10 +27,12 @@ export const StyledSpacer = styled.div`
 export const SidebarAuth = ({
   view,
   setView,
+  currentNotification,
   setNotification,
   isLoading,
 }: {
   isLoading: boolean;
+  currentNotification: UserNotificationObjectType | null;
   setNotification: React.Dispatch<
     React.SetStateAction<UserNotificationObjectType | null>
   >;
@@ -57,7 +59,6 @@ export const SidebarAuth = ({
     usernameOrPasswordWrong,
     ooops,
     checkMailForPasswordReset,
-    usernameTaken,
   } = content.auth.errors;
 
   const {
@@ -317,6 +318,7 @@ export const SidebarAuth = ({
           handleSubmit={handleSignInSubmit}
           buttonText={signinAction}
           isSignIn={true}
+          currentNotification={currentNotification}
         />
       );
       linkText = (
@@ -337,6 +339,7 @@ export const SidebarAuth = ({
           buttonText={signupAction}
           usernamePatterns={usernamePatterns}
           isUsernameTaken={isUsernameTaken}
+          currentNotification={currentNotification}
           isSignIn={false}
         />
       );
@@ -358,6 +361,7 @@ export const SidebarAuth = ({
           handleSubmit={handleRecoverySubmit}
           buttonText={resetPassword}
           isRecovery={true}
+          currentNotification={currentNotification}
         />
       );
       linkText = (


### PR DESCRIPTION
This PR moves the error notification on authentication/registration/password recover views further up for better visibility on mobile screen sizes:

Before:
![Screen Shot 2024-02-12 at 11 35 50](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/aa5b9b1c-b33d-470d-9e8b-a8e6e6a76eee)

After:
![Screen Shot 2024-02-12 at 11 36 16](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/e1d5a9e6-390d-4b25-bfd0-826d8e6e7837)
