### PR TITLE
feat: move and style language button

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -13,6 +13,9 @@ import Loading from '../Loading';
 import Nav from '../Nav';
 import Overlay from '../Overlay';
 import { getLocalStorageLanguage } from '../../assets/local-storage';
+import Switch from '../Switch';
+import { Language } from '../../assets/content-types';
+import { setLocalStorageLanguage } from '../../assets/local-storage';
 
 const Map = dynamic(() => import('../TreesMap'), { ssr: false });
 
@@ -70,6 +73,7 @@ const App: FC<{ children: React.ReactNode }> = ({ children }) => {
   const showOverlay = isHome && overlay;
   const showMapUI = !showOverlay;
   const isSidebarOpened = !isHome && isNavOpen;
+  const language = useStoreState('language');
   const { setLanguage } = useActions();
 
   useEffect(() => {
@@ -84,6 +88,7 @@ const App: FC<{ children: React.ReactNode }> = ({ children }) => {
       {showMapUI && children}
       {showOverlay && <Overlay />}
       {showMapUI && <Nav isNavOpened={!isHome} />}
+
       <Cookie />
       {showMapUI && <MapLayerLegend />}
       <ImprintAndPrivacyContainer>
@@ -101,6 +106,15 @@ const App: FC<{ children: React.ReactNode }> = ({ children }) => {
           height={23}
         />
       </MapboxLogo>
+      <Switch
+        firstOption={Language.de}
+        secondOption={Language.en}
+        selectedOption={language}
+        onOptionSelect={option => {
+          setLocalStorageLanguage(option as Language);
+          setLanguage(option as Language);
+        }}
+      ></Switch>
     </AppContainer>
   );
 };

--- a/src/components/Overlay/OverlayTop/index.tsx
+++ b/src/components/Overlay/OverlayTop/index.tsx
@@ -12,6 +12,10 @@ import OverlayClose from '../OverlayClose';
 import OverlayTiles from '../OverlayTiles';
 import useLocalizedContent from '../../../utils/hooks/useLocalizedContent';
 
+import Switch from '../../Switch';
+import { Language } from '../../../assets/content-types';
+import { setLocalStorageLanguage } from '../../../assets/local-storage';
+
 const StyledNewsSection = styled.section`
   background-color: #f7fffa;
   border: 1px solid ${({ theme }) => theme.colorPrimaryHover};
@@ -117,9 +121,7 @@ const OverlayTop: FC = () => {
         <OverlayTitle size='xxl' title={title} />
         <Icon iconType='trees' />
 
-        {/*
-          TODO: Uncomment as soon as all translations are reviewed and ready
-         <Switch
+        <Switch
           firstOption={Language.de}
           secondOption={Language.en}
           selectedOption={language}
@@ -127,7 +129,7 @@ const OverlayTop: FC = () => {
             setLocalStorageLanguage(option as Language);
             setLanguage(option as Language);
           }}
-        ></Switch> */}
+        ></Switch>
       </Logo>
       <OverlayTitle size='xxl' title={subline} />
       {/* the beow is here for local testing */}

--- a/src/components/Overlay/OverlayTop/index.tsx
+++ b/src/components/Overlay/OverlayTop/index.tsx
@@ -1,20 +1,16 @@
 import React, { FC, useEffect } from 'react';
 import styled from 'styled-components';
 
-import OverlayTitle from '../OverlayTitle/';
-import Icon from '../../Icons';
-import OverlayDescription from '../OverlayDescription/';
 import ButtonRound from '../../ButtonRound';
 import Credits from '../../Credits';
+import Icon from '../../Icons';
+import OverlayDescription from '../OverlayDescription/';
+import OverlayTitle from '../OverlayTitle/';
 
 import { useActions, useStoreState } from '../../../state/unistore-hooks';
+import useLocalizedContent from '../../../utils/hooks/useLocalizedContent';
 import OverlayClose from '../OverlayClose';
 import OverlayTiles from '../OverlayTiles';
-import useLocalizedContent from '../../../utils/hooks/useLocalizedContent';
-
-import Switch from '../../Switch';
-import { Language } from '../../../assets/content-types';
-import { setLocalStorageLanguage } from '../../../assets/local-storage';
 
 const StyledNewsSection = styled.section`
   background-color: #f7fffa;
@@ -120,16 +116,6 @@ const OverlayTop: FC = () => {
       <Logo>
         <OverlayTitle size='xxl' title={title} />
         <Icon iconType='trees' />
-
-        <Switch
-          firstOption={Language.de}
-          secondOption={Language.en}
-          selectedOption={language}
-          onOptionSelect={option => {
-            setLocalStorageLanguage(option as Language);
-            setLanguage(option as Language);
-          }}
-        ></Switch>
       </Logo>
       <OverlayTitle size='xxl' title={subline} />
       {/* the beow is here for local testing */}

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -2,40 +2,47 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 const StyledSwitch = styled.div`
+  position: fixed;
+  right: 10px;
+  top: 10px;
+  background-color: white;
+  width: 52px;
+  height: 65px;
+  border-radius: 10px;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   flex-wrap: wrap;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.125));
 `;
 
 const StyledSwitchLeft = styled.div<{ $isActive?: boolean }>`
-  border-right: 1px solid black;
-  border-left: 1px solid black;
-  border-top: 1px solid black;
-  border-bottom: 1px solid black;
-  border-top-left-radius: 5px;
-  border-bottom-left-radius: 5px;
-  padding: 6px;
+  padding-top: 5%;
+  height: 45%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  border-radius: 10px 10px 0 0;
+  text-decoration: ${p => p.$isActive && 'underline'};
+  font-weight: ${p => p.$isActive && 'bold'};
   &:hover {
-    background-color: ${p => p.theme.colorPrimaryDark};
-    color: white;
+    text-decoration: underline;
   }
-  background-color: ${p => p.$isActive && p.theme.colorPrimary};
 `;
 
 const StyledSwitchRight = styled.div<{ $isActive?: boolean }>`
-  border-right: 1px solid black;
-  border-top: 1px solid black;
-  border-bottom: 1px solid black;
-  border-top-right-radius: 5px;
-  border-bottom-right-radius: 5px;
-  padding: 6px;
+  padding-bottom: 5%;
+  height: 45%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  border-radius: 0 0 10px 10px;
+  text-decoration: ${p => p.$isActive && 'underline'};
+  font-weight: ${p => p.$isActive && 'bold'};
   &:hover {
-    background-color: ${p => p.theme.colorPrimaryDark};
-    color: white;
+    text-decoration: underline;
   }
-  background-color: ${p => p.$isActive && p.theme.colorPrimary};
 `;
 
 interface SwitchProps {
@@ -60,7 +67,7 @@ const Switch: FC<SwitchProps> = ({
             onOptionSelect(firstOption);
           }}
         >
-          {firstOption}
+          {firstOption.toUpperCase()}
         </StyledSwitchLeft>
         <StyledSwitchRight
           $isActive={selectedOption === secondOption}
@@ -68,7 +75,7 @@ const Switch: FC<SwitchProps> = ({
             onOptionSelect(secondOption);
           }}
         >
-          {secondOption}
+          {secondOption.toUpperCase()}
         </StyledSwitchRight>
       </StyledSwitch>
     </>

--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import styled from 'styled-components';
 
 const StyledSwitch = styled.div`
+  z-index: 4;
   position: fixed;
   right: 10px;
   top: 10px;


### PR DESCRIPTION
- moved language button to fixed top right position
- added styling according to new design on figma
- the language button is currently rendered double in OverlayTop (where it already was) AND in the main App file. Otherwise clicking the language button outside the splash screen would always close the splash screen.

https://app.asana.com/0/1204152181784036/1206565413148089/f