### PR TITLE
fix: z-index of overlay

### DIFF
--- a/src/components/Overlay/index.tsx
+++ b/src/components/Overlay/index.tsx
@@ -13,10 +13,10 @@ const StyledWrapper = styled.div`
   position: relative;
   overflow-y: auto;
   background-color: white;
-  box-shadow: ${(p) => p.theme.boxShadow};
+  box-shadow: ${p => p.theme.boxShadow};
   z-index: 3;
 
-  @media screen and (max-width: ${(p) => p.theme.screens.tablet}) {
+  @media screen and (max-width: ${p => p.theme.screens.tablet}) {
     width: 100%;
     height: 100%;
     box-shadow: none;
@@ -38,18 +38,18 @@ const OverlayOverlay = styled.button`
 
 const StyledOverlayWrapper = styled.div`
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh - 80px);
   display: flex;
   align-items: center;
-  position: fixed;
-  top: 0;
+  position: absolute;
+  z-index: 3;
+  top: 80px;
   left: 0;
 `;
 
 const Wrapper = styled.div`
   width: 100%;
-  padding-bottom: 20px;
-  max-height: calc(100vh - 40px);
+  max-height: calc(100vh - 80px);
   display: grid;
   grid-template:
     'intro'


### PR DESCRIPTION
fixes the z-index and margin top of overlay (splashscreen):

Before: language switch is over the close button of the overlay, mapbox logo and map imprint links is over the overlay

![Bildschirmfoto 2024-03-01 um 13 11 09](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/4d89793b-3868-42e8-84c5-c0681199f750)

After: moved the overlay lower down to not clash with language switch, increased z-index of overlay to keep mapbox logo and map imprint links below
![Bildschirmfoto 2024-03-01 um 13 11 24](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/36683364-7991-457c-8d1f-b0da4d16c0d9)
