### PR TITLE
feat: add shadow and exchange on pages

### DIFF
--- a/src/components/location-search/location-search.tsx
+++ b/src/components/location-search/location-search.tsx
@@ -51,7 +51,7 @@ const LocationSearch: React.FC = () => {
   return (
     <div className="mt-2 flex w-full justify-center">
       <div
-        className={`pointer-events-auto z-[2] flex h-fit w-[100%] flex-col px-2 drop-shadow-xl sm:w-[50%] sm:px-0 md:w-[40%] lg:w-[35%] xl:w-[25%] `}
+        className={`pointer-events-auto z-[2] flex h-fit w-[100%] flex-col px-2 drop-shadow-md sm:w-[50%] sm:px-0 md:w-[40%] lg:w-[35%] xl:w-[25%] `}
       >
         <form
           onSubmit={(e) => {

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -25,8 +25,8 @@ const Navbar: React.FC = () => {
 
   return (
     <nav
-      className={`pointer-events-auto
-      flex h-auto w-full justify-center rounded-tl-3xl rounded-tr-3xl bg-white pt-0 shadow 
+      className={`shadow-gdk-hard
+      pointer-events-auto flex h-auto w-full justify-center rounded-tl-3xl rounded-tr-3xl bg-white pt-0 
       lg:h-full lg:w-auto lg:justify-start lg:rounded-br lg:rounded-tl-none lg:rounded-tr lg:px-2 lg:pt-10`}
     >
       <div

--- a/src/components/profile/adopted-trees.tsx
+++ b/src/components/profile/adopted-trees.tsx
@@ -18,7 +18,7 @@ const AdoptedTrees: React.FC = () => {
   );
 
   return (
-    <div className="mb-3 md:rounded-2xl md:border-2 md:p-7 md:shadow-sm">
+    <div className="md:shadow-gdk-soft mb-3 md:rounded-2xl md:border-2 md:p-7">
       <h2 className="text-2xl font-semibold">
         {i18n.navbar.profile.overview.adoptedTrees}
       </h2>

--- a/src/components/profile/overview.tsx
+++ b/src/components/profile/overview.tsx
@@ -19,13 +19,13 @@ const Overview: React.FC = () => {
   );
 
   return (
-    <div className="mb-3 md:rounded-2xl md:border md:border-2 md:p-7 md:shadow-sm">
+    <div className="md:shadow-gdk-soft mb-3 md:rounded-2xl md:border md:border-2 md:p-7">
       <h2 className="text-2xl font-semibold">
         {i18n.navbar.profile.overview.subtitle}
       </h2>
 
       <div className="mt-7 flex flex-col gap-3 lg:flex-row ">
-        <div className="flex  flex-col justify-between gap-3 rounded-2xl  border-2 p-4 font-semibold shadow-sm">
+        <div className="shadow-gdk-soft  flex flex-col justify-between gap-3  rounded-2xl border-2 p-4 font-semibold">
           {i18n.navbar.profile.overview.liter}
           <span className="flex items-baseline gap-x-5 text-5xl font-medium">
             <img src="images/icon-drop.svg" alt="" className="w-5" />
@@ -34,7 +34,7 @@ const Overview: React.FC = () => {
         </div>
 
         <div className="flex gap-3">
-          <div className="flex w-full flex-col justify-between gap-3 rounded-2xl  border-2 p-4 font-semibold shadow-sm">
+          <div className="shadow-gdk-soft flex w-full flex-col justify-between gap-3  rounded-2xl border-2 p-4 font-semibold">
             {i18n.navbar.profile.overview.adoptedTrees}
             <span className="flex items-baseline gap-x-5 text-5xl font-medium">
               <img src="images/icon-tree.svg" alt="" className="w-[1.625rem]" />
@@ -42,7 +42,7 @@ const Overview: React.FC = () => {
             </span>
           </div>
 
-          <div className="flex w-full flex-col justify-between gap-3 rounded-2xl  border-2 p-4 font-semibold shadow-sm">
+          <div className="shadow-gdk-soft flex w-full flex-col justify-between gap-3  rounded-2xl border-2 p-4 font-semibold">
             {i18n.navbar.profile.overview.irrigations}
             <span className="flex items-baseline gap-x-5 text-5xl font-medium">
               <img src="images/icon-watering-can.svg" alt="" className="" />

--- a/src/components/profile/profile-details.tsx
+++ b/src/components/profile/profile-details.tsx
@@ -10,7 +10,7 @@ const ProfileDetails: React.FC = () => {
   const [emailIsDisabled, setEmailDisabled] = useState(true);
 
   return (
-    <div className="mb-3 md:rounded-2xl md:border-2 md:p-7 md:shadow-sm">
+    <div className="md:shadow-gdk-soft mb-3 md:rounded-2xl md:border-2 md:p-7">
       <h2 className="text-2xl font-semibold">
         {i18n.navbar.profile.settings.subtitle}
       </h2>

--- a/src/components/profile/tree-card.tsx
+++ b/src/components/profile/tree-card.tsx
@@ -20,7 +20,7 @@ const TreeCard: React.FC<TreeCardProps> = ({
   return (
     <div
       key={id}
-      className="flex flex-col gap-3 rounded-2xl border-2 p-4 shadow-sm "
+      className="shadow-gdk-soft flex flex-col gap-3 rounded-2xl border-2 p-4 "
     >
       <a
         className="py-2 font-semibold text-blue-600 hover:text-gdk-light-blue"

--- a/src/components/tree-detail/tree-adopt-card.tsx
+++ b/src/components/tree-detail/tree-adopt-card.tsx
@@ -9,7 +9,7 @@ interface TreeAdoptCardProps {
 const TreeAdoptCard: React.FC<TreeAdoptCardProps> = ({ treeData }) => {
   const i18n = useI18nStore().i18n();
   return (
-    <div className="flex flex-col gap-4 rounded-lg bg-slate-100 p-4 drop-shadow-lg">
+    <div className="shadow-gdk-hard flex flex-col gap-4 rounded-lg bg-slate-100 p-4">
       <div className="flex flex-row items-center justify-between text-xl">
         <div className="font-bold">{treeData.artdtsch}</div>
         <img

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,11 @@ export default {
         "gdk-dark-green": "#07964E",
         "gdk-purple": "#660A9C",
       },
+      boxShadow: {
+        "3xl": "0 35px 60px -15px rgba(0, 0, 0, 0.3)",
+        "gdk-soft": "0px 3px 6px 0px rgba(184, 184, 184, 0.10);",
+        "gdk-hard": "0px 3px 6px 0px rgba(105, 105, 105, 0.20);",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
we have two defined shadows now:
- shadow-gdk-hard
- and shadow-gdk-soft

I used box-shadow when possible (except for the searchbar, bc of its round shape), because I had some bugs with drop shadow being inherited by other elements.