### PR TITLE
feat: finished registration use-case and fixed linting errors

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,7 @@
 VITE_BASE_URL=http://localhost:5173
 
 # Supabase will redirect to this url after recovery
-VITE_RECOVERY_AUTH_REDIRECT_URL=${VITE_BASE_URL}/reset-password
+VITE_RECOVERY_AUTH_REDIRECT_URL=${VITE_BASE_URL}/profile/reset-password
 
 # Mapbox Credentials
 VITE_MAPBOX_API_KEY=pk.123.xyz
@@ -34,6 +34,7 @@ NEXT_PUBLIC_MAP_INITIAL_ZOOM_MOBILE=13
 # giessdenkiez API
 # See https://github.com/technologiestiftung/giessdenkiez-de-postgres-api
 VITE_SUPABASE_URL=http://localhost:54321
+INBUCKET_URL=http://localhost:54324
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 VITE_API_ENDPOINT=http://localhost:8080
 

--- a/src/components/profile/auth-card/auth-card.tsx
+++ b/src/components/profile/auth-card/auth-card.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useUrlState } from "../../router/store";
-import Login from "./login.tsx";
-import Register from "./register";
-import ForgotPassword from "./forgot-password";
+import { Login } from "./login";
+import { Register } from "./register";
+import { ForgotPassword } from "./forgot-password";
 
-const AuthCard: React.FC = () => {
+export const AuthCard: React.FC = () => {
 	const { url } = useUrlState();
 
 	const authType = url.searchParams.get("mode");
@@ -18,5 +18,3 @@ const AuthCard: React.FC = () => {
 			return <Login />;
 	}
 };
-
-export default AuthCard;

--- a/src/components/profile/auth-card/forgot-password.tsx
+++ b/src/components/profile/auth-card/forgot-password.tsx
@@ -4,12 +4,23 @@ import PrimaryButton from "../../buttons/primary";
 import TextInput from "../../input/text-input";
 import { useUrlState } from "../../router/store";
 import { useI18nStore } from "../../../i18n/i18n-store";
+import { useErrorStore } from "../../../error/error-store";
 
-const ForgotPassword: React.FC = () => {
+export const ForgotPassword: React.FC = () => {
 	const { forgotPassword } = useAuthStore();
 	const { setPathname } = useUrlState();
-
 	const i18n = useI18nStore().i18n();
+	const { handleError } = useErrorStore();
+
+	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		try {
+			await forgotPassword(e.currentTarget.email.value);
+		} catch (error) {
+			handleError(i18n.common.defaultErrorMessage);
+		}
+	};
 
 	return (
 		<>
@@ -26,21 +37,15 @@ const ForgotPassword: React.FC = () => {
 
 			<h1 className="pt-12 text-2xl font-semibold">
 				{" "}
-				{i18n.navbar.profile.settings.passwordForgotten}
-			</h1>
-			<form
-				onSubmit={(e) => {
-					e.preventDefault();
-					forgotPassword(e.currentTarget.email.value);
-				}}
-				className="flex flex-col"
-			>
-				<div className="flex flex-col gap-y-2 pt-7">
-					<label htmlFor="email" className="">
-						{i18n.navbar.profile.settings.email}
-					</label>
-					<TextInput type="email" id="email" name="email" />
-				</div>
+					{i18n.navbar.profile.settings.passwordForgotten}
+				</h1>
+				<form onSubmit={onSubmit} className="flex flex-col">
+					<div className="flex flex-col gap-y-2 pt-7">
+						<label htmlFor="email" className="">
+							{i18n.navbar.profile.settings.email}
+						</label>
+						<TextInput type="email" id="email" name="email" required />
+					</div>
 
 				<div className="pt-11">
 					<PrimaryButton
@@ -64,5 +69,3 @@ const ForgotPassword: React.FC = () => {
 		</>
 	);
 };
-
-export default ForgotPassword;

--- a/src/components/profile/auth-card/login.tsx
+++ b/src/components/profile/auth-card/login.tsx
@@ -4,39 +4,50 @@ import PrimaryButton from "../../buttons/primary";
 import TextInput from "../../input/text-input";
 import { useUrlState } from "../../router/store";
 import { useI18nStore } from "../../../i18n/i18n-store";
+import { useErrorStore } from "../../../error/error-store";
+import { getErrorMessage } from "../validation/validation.ts";
 
-const Login: React.FC = () => {
+export const Login: React.FC = () => {
 	const { login } = useAuthStore();
 	const { setSearchParams } = useUrlState();
 	const i18n = useI18nStore().i18n();
+	const { handleError } = useErrorStore();
+
+	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		try {
+			await login({
+				email: e.currentTarget.email.value,
+				password: e.currentTarget.password.value,
+			});
+		} catch (error) {
+			if (getErrorMessage(error) === "Invalid login credentials") {
+				handleError(i18n.navbar.profile.settings.invalidCredentials);
+				return;
+			}
+
+			handleError(i18n.common.defaultErrorMessage);
+		}
+	};
 
 	return (
 		<>
 			<h1 className="text-2xl font-semibold">
-				{i18n.navbar.profile.settings.logInShort}
-			</h1>
-			<form
-				onSubmit={(e) => {
-					e.preventDefault();
-					login({
-						email: e.currentTarget.email.value,
-						password: e.currentTarget.password.value,
-					});
-				}}
-				className="flex flex-col"
-			>
-				<div className="flex flex-col gap-y-2 pt-7">
-					<label htmlFor="email" className="">
-						{i18n.navbar.profile.settings.email}
-					</label>
-					<TextInput type="email" id="email" name="email" />
-				</div>
+					{i18n.navbar.profile.settings.logInShort}
+				</h1>
+				<form onSubmit={onSubmit} className="flex flex-col">
+					<div className="flex flex-col gap-y-2 pt-7">
+						<label htmlFor="email" className="">
+							{i18n.navbar.profile.settings.email}
+						</label>
+						<TextInput type="email" id="email" name="email" required />
+					</div>
 
 				<div className="flex flex-col gap-y-2 pt-6">
 					<label htmlFor="password" className="">
 						{i18n.navbar.profile.settings.password}
 					</label>
-					<TextInput type="password" id="password" name="password" />
+					<TextInput type="password" id="password" name="password" required />
 				</div>
 
 				<div className="pt-11">
@@ -59,21 +70,19 @@ const Login: React.FC = () => {
 				{i18n.navbar.profile.settings.registerNow}
 			</a>
 
-			<p className="pt-6">
-				{i18n.navbar.profile.settings.ohNoforgotYourPassword}
-			</p>
-			<a
-				className="font-semibold text-blue-600"
-				href="/profile?mode=forgot-password"
-				onClick={(e) => {
-					e.preventDefault();
-					setSearchParams(new URLSearchParams("mode=forgot-password"));
-				}}
-			>
-				{i18n.navbar.profile.settings.forgotYourPassword}
-			</a>
+				<p className="pt-6">
+					{i18n.navbar.profile.settings.ohNoforgotYourPassword}
+				</p>
+				<a
+					className="font-semibold text-blue-600"
+					href="/profile?mode=forgot-password"
+					onClick={(e) => {
+						e.preventDefault();
+						setSearchParams(new URLSearchParams("mode=forgot-password"));
+					}}
+				>
+					{i18n.navbar.profile.settings.forgotYourPassword}
+				</a>
 		</>
 	);
 };
-
-export default Login;

--- a/src/components/profile/auth-card/register.tsx
+++ b/src/components/profile/auth-card/register.tsx
@@ -2,23 +2,41 @@ import React, { useCallback } from "react";
 import { useUrlState } from "../../router/store";
 import { useAuthStore } from "../../../auth/auth-store";
 import { useI18nStore } from "../../../i18n/i18n-store";
-import EmailInputWithValidation from "../validation/email-input-with-validation";
-import UsernameInputWithValidation from "../validation/username-input-with-validation";
-import PasswordInputWithValidation from "../validation/password-input-with-validation";
+import { EmailInputWithValidation } from "../validation/email-input-with-validation";
+import { UsernameInputWithValidation } from "../validation/username-input-with-validation";
+import { PasswordInputWithValidation } from "../validation/password-input-with-validation";
 import PrimaryButton from "../../buttons/primary";
+import { useEmailTakenStore } from "../validation/email-taken-store";
+import { getErrorMessage } from "../validation/validation";
+import { useErrorStore } from "../../../error/error-store";
 
-const Register: React.FC = () => {
+export const Register: React.FC = () => {
 	const { setPathname } = useUrlState();
 	const { register } = useAuthStore();
+	const { setIsEmailTaken } = useEmailTakenStore();
 	const i18n = useI18nStore().i18n();
+	const { handleError } = useErrorStore();
 
-	const onSubmit = useCallback((e: React.FormEvent<HTMLFormElement>) => {
+	const onSubmit = useCallback(async (e: React.FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
-		register({
-			email: e.currentTarget.email.value,
-			username: e.currentTarget.username.value,
-			password: e.currentTarget.password.value,
-		});
+		const form = e.currentTarget;
+
+		try {
+			await register({
+				email: form.email.value,
+				username: form.username.value,
+				password: form.password.value,
+			});
+		} catch (error) {
+			if (getErrorMessage(error) === "User already registered") {
+				setIsEmailTaken(true);
+				form.email.setCustomValidity("Bitte überprüfe Deine Eingabe");
+				form.reportValidity();
+				return;
+			}
+
+			handleError(i18n.common.defaultErrorMessage);
+		}
 	}, []);
 
 	return (
@@ -76,5 +94,3 @@ const Register: React.FC = () => {
 		</>
 	);
 };
-
-export default Register;

--- a/src/components/profile/profile-logged-in/adopted-trees.tsx
+++ b/src/components/profile/profile-logged-in/adopted-trees.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
 import { useI18nStore } from "../../../i18n/i18n-store";
 import TertiaryButton from "../../buttons/tertiary";
-import TreeCard from "./tree-card";
+import { TreeCard } from "./tree-card";
 
-const AdoptedTrees: React.FC = () => {
+export const AdoptedTrees: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const [showAllTrees, setshowAllTrees] = useState(false);
 
@@ -60,5 +60,3 @@ const AdoptedTrees: React.FC = () => {
 		</div>
 	);
 };
-
-export default AdoptedTrees;

--- a/src/components/profile/profile-logged-in/overview.tsx
+++ b/src/components/profile/profile-logged-in/overview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useI18nStore } from "../../../i18n/i18n-store";
 
-const Overview: React.FC = () => {
+export const Overview: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const { formatNumber } = useI18nStore();
 
@@ -54,5 +54,3 @@ const Overview: React.FC = () => {
 		</div>
 	);
 };
-
-export default Overview;

--- a/src/components/profile/profile-logged-in/password-reset.tsx
+++ b/src/components/profile/profile-logged-in/password-reset.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { useAuthStore } from "../../../auth/auth-store";
-import PasswordInputWithValidation from "../validation/password-input-with-validation";
+import { PasswordInputWithValidation } from "../validation/password-input-with-validation";
 import PrimaryButton from "../../buttons/primary";
 import { useUrlState } from "../../router/store";
 
-const PasswordReset: React.FC = () => {
+export const PasswordReset: React.FC = () => {
 	const { updatePassword } = useAuthStore();
 
 	const { setPathname } = useUrlState();
@@ -45,5 +45,3 @@ const PasswordReset: React.FC = () => {
 		</div>
 	);
 };
-
-export default PasswordReset;

--- a/src/components/profile/profile-logged-in/profile-details/edit-password.tsx
+++ b/src/components/profile/profile-logged-in/profile-details/edit-password.tsx
@@ -1,11 +1,21 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useI18nStore } from "../../../../i18n/i18n-store";
 import { useAuthStore } from "../../../../auth/auth-store";
 import TertiaryButton from "../../../buttons/tertiary";
+import { useErrorStore } from "../../../../error/error-store";
 
-const EditPassword: React.FC = () => {
+export const EditPassword: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const { forgotPassword, getUserData } = useAuthStore();
+	const { handleError } = useErrorStore();
+
+	const onClick = useCallback(async () => {
+		try {
+			await forgotPassword(getUserData()?.email ?? "");
+		} catch (error) {
+			handleError(i18n.common.defaultErrorMessage);
+		}
+	}, []);
 
 	return (
 		<div className="mt-7 flex flex-col">
@@ -21,14 +31,10 @@ const EditPassword: React.FC = () => {
 					value="1234567890"
 				/>
 				<TertiaryButton
-					onClick={() => {
-						forgotPassword(getUserData()?.email ?? "");
-					}}
+					onClick={onClick}
 					label={i18n.navbar.profile.settings.changePassword}
 				></TertiaryButton>
 			</div>
 		</div>
 	);
 };
-
-export default EditPassword;

--- a/src/components/profile/profile-logged-in/profile-details/edit-username.tsx
+++ b/src/components/profile/profile-logged-in/profile-details/edit-username.tsx
@@ -2,43 +2,40 @@ import React, { useState } from "react";
 import { useI18nStore } from "../../../../i18n/i18n-store";
 import EditIcon from "../../../icons/edit-icon";
 import { useAuthStore } from "../../../../auth/auth-store";
-import UsernameInputWithValidation from "../../validation/username-input-with-validation";
+import { UsernameInputWithValidation } from "../../validation/username-input-with-validation";
+import { useErrorStore } from "../../../../error/error-store";
 
-const EditUsername: React.FC = () => {
+export const EditUsername: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const { updateUsername, getUserData } = useAuthStore();
+	const { handleError } = useErrorStore();
 
-	const [usernameIsDisabled, setUsernameDisabled] = useState(true);
+	const [isUsernameInputEnabled, setIsUsernameInputEnabled] = useState(false);
+
+	const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+		const form = e.currentTarget;
+		setIsUsernameInputEnabled(false);
+
+		const isSameUsername =
+			form.username.value === getUserData()?.user_metadata.signup_username;
+		if (isSameUsername) {
+			return;
+		}
+
+		try {
+			await updateUsername(e.currentTarget.username.value);
+		} catch (error) {
+			handleError(i18n.common.defaultErrorMessage);
+		}
+	};
 
 	return (
 		<div className="mt-7 flex flex-col">
-			{usernameIsDisabled ? (
-				<>
-					<p className="mb-2 font-semibold">
-						{i18n.navbar.profile.settings.username}
-					</p>
-					<div className="flex flex-row justify-between gap-x-8">
-						<p className="italic">
-							{getUserData()?.user_metadata.signup_username}
-						</p>
-						<button
-							className="self-end text-gdk-blue enabled:hover:text-gdk-light-blue"
-							onClick={() => {
-								setUsernameDisabled(!usernameIsDisabled);
-							}}
-						>
-							<EditIcon />
-						</button>
-					</div>
-				</>
-			) : (
+			{isUsernameInputEnabled ? (
 				<form
 					className="flex flex-col justify-between gap-x-8"
-					onSubmit={(e) => {
-						e.preventDefault();
-						updateUsername(e.currentTarget.username.value);
-						setUsernameDisabled(!usernameIsDisabled);
-					}}
+					onSubmit={onSubmit}
 				>
 					<div className="flex flex-col justify-between gap-x-8 md:flex-row">
 						<UsernameInputWithValidation
@@ -54,9 +51,26 @@ const EditUsername: React.FC = () => {
 						</button>
 					</div>
 				</form>
+			) : (
+				<>
+					<p className="mb-2 font-semibold">
+						{i18n.navbar.profile.settings.username}
+					</p>
+					<div className="flex flex-row justify-between gap-x-8">
+						<p className="italic">
+							{getUserData()?.user_metadata.signup_username}
+						</p>
+						<button
+							className="self-end text-gdk-blue enabled:hover:text-gdk-light-blue"
+							onClick={() => {
+								setIsUsernameInputEnabled(true);
+							}}
+						>
+							<EditIcon />
+						</button>
+					</div>
+				</>
 			)}
 		</div>
 	);
 };
-
-export default EditUsername;

--- a/src/components/profile/profile-logged-in/profile-details/profile-details.tsx
+++ b/src/components/profile/profile-logged-in/profile-details/profile-details.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback } from "react";
 import { useI18nStore } from "../../../../i18n/i18n-store";
-import EditEmail from "./edit-email";
-import EditUsername from "./edit-username";
-import EditPassword from "./edit-password";
+import { EditEmail } from "./edit-email";
+import { EditUsername } from "./edit-username";
+import { EditPassword } from "./edit-password";
 import TertiaryDestructiveButton from "../../../buttons/tertiary-destructive";
 import { useAuthStore } from "../../../../auth/auth-store";
 import { useErrorStore } from "../../../../error/error-store";
 import { useUrlState } from "../../../router/store";
 
-const ProfileDetails: React.FC = () => {
+export const ProfileDetails: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const { deleteUser } = useAuthStore();
 	const { handleError } = useErrorStore();
@@ -39,5 +39,3 @@ const ProfileDetails: React.FC = () => {
 		</div>
 	);
 };
-
-export default ProfileDetails;

--- a/src/components/profile/profile-logged-in/profile-logged-in.tsx
+++ b/src/components/profile/profile-logged-in/profile-logged-in.tsx
@@ -1,18 +1,29 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useUrlState } from "../../router/store";
 import { useI18nStore } from "../../../i18n/i18n-store";
 import { useAuthStore } from "../../../auth/auth-store";
-import Overview from "./overview";
-import AdoptedTrees from "./adopted-trees";
-import ProfileDetails from "./profile-details/profile-details";
+import { Overview } from "./overview";
+import { AdoptedTrees } from "./adopted-trees";
+import { ProfileDetails } from "./profile-details/profile-details";
 import SecondaryButton from "../../buttons/secondary";
-import PasswordReset from "./password-reset";
+import { PasswordReset } from "./password-reset";
+import { useErrorStore } from "../../../error/error-store.tsx";
 
-const ProfileLoggedIn: React.FC = () => {
+export const ProfileLoggedIn: React.FC = () => {
 	const i18n = useI18nStore().i18n();
 	const { logout } = useAuthStore();
-	const { url } = useUrlState();
+	const { url, setSearchParams } = useUrlState();
 	const authType = url.searchParams.get("mode");
+	const { handleError } = useErrorStore();
+
+	const onClick = useCallback(async () => {
+		try {
+			await logout();
+			setSearchParams(new URLSearchParams());
+		} catch (error) {
+			handleError(i18n.common.defaultErrorMessage);
+		}
+	}, []);
 
 	if (authType === "reset-password") {
 		return <PasswordReset />;
@@ -32,7 +43,7 @@ const ProfileLoggedIn: React.FC = () => {
 
 					<div className="self-center">
 						<SecondaryButton
-							onClick={() => logout()}
+							onClick={onClick}
 							label={i18n.navbar.profile.logOut}
 						/>
 					</div>
@@ -41,5 +52,3 @@ const ProfileLoggedIn: React.FC = () => {
 		</div>
 	);
 };
-
-export default ProfileLoggedIn;

--- a/src/components/profile/profile-logged-in/tree-card.tsx
+++ b/src/components/profile/profile-logged-in/tree-card.tsx
@@ -8,7 +8,7 @@ export interface TreeCardProps {
 	irrigationTimes: number;
 }
 
-const TreeCard: React.FC<TreeCardProps> = ({
+export const TreeCard: React.FC<TreeCardProps> = ({
 	id,
 	name,
 	irrigationAmount,
@@ -52,5 +52,3 @@ const TreeCard: React.FC<TreeCardProps> = ({
 		</div>
 	);
 };
-
-export default TreeCard;

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useAuthStore } from "../../auth/auth-store";
-import AuthCard from "./auth-card/auth-card";
-import ProfileLoggedIn from "./profile-logged-in/profile-logged-in";
+import { AuthCard } from "./auth-card/auth-card";
+import { ProfileLoggedIn } from "./profile-logged-in/profile-logged-in";
 
 const Profile: React.FC = () => {
 	const { isLoggedIn } = useAuthStore();

--- a/src/components/profile/validation/email-input-with-validation.tsx
+++ b/src/components/profile/validation/email-input-with-validation.tsx
@@ -1,18 +1,30 @@
 import React from "react";
 import TextInput from "../../input/text-input";
+import { Warning } from "./warning";
+import { useEmailTakenStore } from "./email-taken-store";
+import { useResetIsEmailTakenOnUnmount } from "./hooks/use-reset-is-email-taken-on-unmount.tsx";
 
 export interface EmailInputValidationProps {
 	label: string | React.ReactNode;
 	defaultValue?: string;
 }
 
-const EmailInputWithValidation: React.FC<EmailInputValidationProps> = ({
+export const EmailInputWithValidation: React.FC<EmailInputValidationProps> = ({
 	label,
 	defaultValue,
 }) => {
+	const { isEmailTaken, resetErrorMessages } = useEmailTakenStore();
+
+	/**
+	 * because the emailTakenStore is shared between the components register.tsx and edit-email.tsx
+	 * we need to reset the warning "e-mail is taken" when this component is unmounted, so that
+	 * the warning is not wrongly shown when they are mounted
+	 */
+	useResetIsEmailTakenOnUnmount();
+
 	return (
-		<div className="flex-auto">
-			<label className="mb-2 font-semibold" htmlFor="email">
+		<>
+			<label className="font-semibold" htmlFor="email">
 				{label}
 			</label>
 			<TextInput
@@ -21,9 +33,11 @@ const EmailInputWithValidation: React.FC<EmailInputValidationProps> = ({
 				name="email"
 				required
 				defaultValue={defaultValue}
+				onChange={(e) => resetErrorMessages(e)}
 			/>
-		</div>
+			{isEmailTaken && (
+				<Warning label="Ein Konto mit dieser E-Mail existiert bereits" />
+			)}
+		</>
 	);
 };
-
-export default EmailInputWithValidation;

--- a/src/components/profile/validation/email-taken-store.ts
+++ b/src/components/profile/validation/email-taken-store.ts
@@ -1,0 +1,21 @@
+import React from "react";
+import { create } from "zustand";
+
+interface EmailTakenStore {
+	isEmailTaken: boolean;
+	setIsEmailTaken: (isVisible: boolean) => void;
+	resetErrorMessages: (e?: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const useEmailTakenStore = create<EmailTakenStore>()((set, get) => ({
+	isEmailTaken: false,
+
+	setIsEmailTaken: (isVisible) => {
+		set({ isEmailTaken: isVisible });
+	},
+
+	resetErrorMessages: (e?) => {
+		e?.target.setCustomValidity("");
+		get().setIsEmailTaken(false);
+	},
+}));

--- a/src/components/profile/validation/hooks/use-reset-is-email-taken-on-unmount.tsx
+++ b/src/components/profile/validation/hooks/use-reset-is-email-taken-on-unmount.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useEmailTakenStore } from "../email-taken-store.ts";
+
+export const useResetIsEmailTakenOnUnmount = () => {
+	const { resetErrorMessages } = useEmailTakenStore();
+
+	useEffect(() => {
+		return () => {
+			resetErrorMessages();
+		};
+	}, []);
+
+	return undefined;
+};

--- a/src/components/profile/validation/password-input-with-validation.tsx
+++ b/src/components/profile/validation/password-input-with-validation.tsx
@@ -8,9 +8,9 @@ export interface PasswordInputValidationProps {
 	label?: string | React.ReactNode;
 }
 
-const PasswordInputWithValidation: React.FC<PasswordInputValidationProps> = ({
-	label,
-}) => {
+export const PasswordInputWithValidation: React.FC<
+	PasswordInputValidationProps
+> = ({ label }) => {
 	const i18n = useI18nStore().i18n();
 
 	const [passwordErrors, setPasswordErrors] = useState<PasswordErrors>({
@@ -41,11 +41,13 @@ const PasswordInputWithValidation: React.FC<PasswordInputValidationProps> = ({
 
 	const onChange = useCallback(
 		({ target }: React.ChangeEvent<HTMLInputElement>) => {
-			const passwordErrors = validatePassword(target.value);
+			const validatedPasswordErrors = validatePassword(target.value);
 
-			setPasswordErrors(passwordErrors);
+			setPasswordErrors(validatedPasswordErrors);
 
-			const hasErrors = Object.values(passwordErrors).some((error) => !error);
+			const hasErrors = Object.values(validatedPasswordErrors).some(
+				(error) => !error,
+			);
 
 			if (!hasErrors) {
 				target.setCustomValidity("");
@@ -87,5 +89,3 @@ const PasswordInputWithValidation: React.FC<PasswordInputValidationProps> = ({
 		</>
 	);
 };
-
-export default PasswordInputWithValidation;

--- a/src/components/profile/validation/username-input-with-validation.tsx
+++ b/src/components/profile/validation/username-input-with-validation.tsx
@@ -1,20 +1,21 @@
 import React, { useCallback, useState } from "react";
 import TextInput from "../../input/text-input";
-import Warning from "./warning";
+import { Warning } from "./warning";
 import { checkIfUsernameIsTaken, validateUsername } from "./validation";
 import { UsernameErrors } from "./types";
 import { useI18nStore } from "../../../i18n/i18n-store";
+import { useErrorStore } from "../../../error/error-store";
 
 export interface UsernameInputValidationProps {
 	label: string | React.ReactNode;
 	defaultValue?: string;
 }
 
-const UsernameInputWithValidation: React.FC<UsernameInputValidationProps> = ({
-	label,
-	defaultValue,
-}) => {
+export const UsernameInputWithValidation: React.FC<
+	UsernameInputValidationProps
+> = ({ label, defaultValue }) => {
 	const i18n = useI18nStore().i18n();
+	const { handleError } = useErrorStore();
 	const [usernameErrors, setUsernameErrors] = useState<UsernameErrors>({
 		validLength: false,
 		onlyNumberAndLetters: false,
@@ -40,26 +41,38 @@ const UsernameInputWithValidation: React.FC<UsernameInputValidationProps> = ({
 		async ({ target }: React.ChangeEvent<HTMLInputElement>) => {
 			setIsUsernameTakenWarningVisible(false);
 
-			const usernameErrors = validateUsername(target.value);
+			const validatedUsernameErrors = validateUsername(target.value);
 
-			setUsernameErrors(usernameErrors);
+			setUsernameErrors(validatedUsernameErrors);
 
-			const hasErrors = Object.values(usernameErrors).some((error) => !error);
+			const hasErrors = Object.values(validatedUsernameErrors).some(
+				(error) => !error,
+			);
 
 			if (hasErrors) {
 				target.setCustomValidity(i18n.navbar.profile.settings.checkInput);
 				return;
 			}
 
-			const isTaken = await checkIfUsernameIsTaken(target.value);
-			setIsUsernameTakenWarningVisible(isTaken);
-
-			if (isTaken) {
-				target.setCustomValidity(i18n.navbar.profile.settings.checkInput);
+			const isSameUsername = target.value === defaultValue;
+			if (isSameUsername) {
+				target.setCustomValidity("");
 				return;
 			}
 
-			target.setCustomValidity("");
+			try {
+				const isTaken = await checkIfUsernameIsTaken(target.value);
+				setIsUsernameTakenWarningVisible(isTaken);
+
+				if (isTaken) {
+					target.setCustomValidity(i18n.navbar.profile.settings.checkInput);
+					return;
+				}
+
+				target.setCustomValidity("");
+			} catch (error) {
+				handleError(i18n.common.defaultErrorMessage, error);
+			}
 		},
 		[],
 	);
@@ -98,5 +111,3 @@ const UsernameInputWithValidation: React.FC<UsernameInputValidationProps> = ({
 		</div>
 	);
 };
-
-export default UsernameInputWithValidation;

--- a/src/components/profile/validation/validation.ts
+++ b/src/components/profile/validation/validation.ts
@@ -3,7 +3,7 @@ import { supabaseClient } from "../../../auth/supabase-client";
 
 export function validatePassword(password: string): PasswordErrors {
 	const validLength = password.length > 8;
-	const upperAndLowerCase = /[a-zA-Z]/.test(password);
+	const upperAndLowerCase = /^(?=.*[a-z])(?=.*[A-Z]).+$/.test(password);
 	const number = /[0-9]/.test(password);
 	const special = /[!@#$%^&*(),.?":{}|<>]/.test(password);
 
@@ -60,4 +60,11 @@ export async function checkIfUsernameIsTaken(
 	});
 
 	return promise;
+}
+
+export function getErrorMessage(error: unknown) {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	return String(error);
 }

--- a/src/components/profile/validation/warning.tsx
+++ b/src/components/profile/validation/warning.tsx
@@ -3,7 +3,7 @@ import React from "react";
 interface WarningProps {
 	label: string;
 }
-const Warning: React.FC<WarningProps> = ({ label }) => {
+export const Warning: React.FC<WarningProps> = ({ label }) => {
 	return (
 		<div
 			className={`flex w-full items-center gap-2.5 rounded bg-gdk-orange px-3 py-4 text-white`}
@@ -13,5 +13,3 @@ const Warning: React.FC<WarningProps> = ({ label }) => {
 		</div>
 	);
 };
-
-export default Warning;

--- a/src/components/router/router.tsx
+++ b/src/components/router/router.tsx
@@ -7,7 +7,7 @@ import Profile from "../profile/profile";
 import TreeDetail from "../tree-detail/tree-detail";
 import { useLocationEventListener } from "./hooks/use-location-event-listener";
 import { useUrlState } from "./store";
-import PasswordReset from "../profile/profile-logged-in/password-reset";
+import { PasswordReset } from "../profile/profile-logged-in/password-reset";
 
 const Router: React.FC = () => {
 	const url = useUrlState((state) => state.url);

--- a/src/error/error-store.tsx
+++ b/src/error/error-store.tsx
@@ -14,7 +14,7 @@ export const useErrorStore = create<ErrorStore>()((set, get) => ({
 	clearErrors: () => set({ error: undefined }),
 
 	handleError: (userFacingErrorMessage: string, thrownError?: any) => {
-		console.log(thrownError);
+		console.error(thrownError);
 		set({ error: userFacingErrorMessage });
 		setTimeout(() => {
 			get().clearErrors();

--- a/src/i18n/content-types.ts
+++ b/src/i18n/content-types.ts
@@ -49,8 +49,10 @@ interface Navbar {
 			email: string;
 			editEmail: string;
 			placeholderMail: string;
+			updateEmailEmailSent: string;
 			password: string;
 			changePassword: string;
+			passwordChangeConfirmation: string;
 			deleteAccount: string;
 			approve: string;
 			usernameShould: string;
@@ -73,8 +75,11 @@ interface Navbar {
 			forgotYourPassword: string;
 			ohNoforgotYourPassword: string;
 			passwordForgotten: string;
+			resetPasswordEmailSent: string;
 			clickHere: string;
 			resetPassword: string;
+			invalidCredentials: string;
+			deleteAccountConfirm: string;
 		};
 		logOut: string;
 	};

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -58,8 +58,12 @@ const de: Content = {
 				email: "Deine E-Mail Adresse",
 				editEmail: "Neue E-Mail Adresse",
 				placeholderMail: "xyz@ts.berlin",
+				updateEmailEmailSent:
+					"Wir haben an Deine alte und neue E–Mail einen Bestätigungslink zum Ändern Deiner Email gesendet. Checke Deine Postfächer und logge Dich neu ein!",
 				password: "Passwort",
 				changePassword: "Passwort ändern",
+				passwordChangeConfirmation:
+					'Dein Passwort wurde geändert. Klicke auf "ok" um zu deinem Profil zu kommen.',
 				deleteAccount: "Account löschen",
 				approve: "Fertig",
 				checkInput: "Bitte überprüfe Deine Eingabe",
@@ -82,8 +86,13 @@ const de: Content = {
 				forgotYourPassword: "Passwort vergessen?",
 				ohNoforgotYourPassword: "Oh nein. Du hast Dein",
 				passwordForgotten: "Passwort Vergessen",
+				resetPasswordEmailSent:
+					"E–Mail gesendet! Wir haben Dir eine E–Mail zum Ändern Deines Passworts gesendet. Checke Dein Postfach!",
 				clickHere: "Hier klicken",
 				resetPassword: "Passwort zurücksetzen",
+				invalidCredentials: "Falsches Passwort oder E-Mail Adresse",
+				deleteAccountConfirm:
+					"Bist du Dir sicher, den Account löschen zu wollen?",
 			},
 			logOut: "Ausloggen",
 		},

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -55,11 +55,15 @@ const en: Content = {
 				username: "Username",
 				editUsername: "New username",
 				placeholderUser: "Your username",
+				updateEmailEmailSent:
+					"We sent you an email with a link to both your old and your new email address to confirm the change. Check your mailbox!",
 				email: "You email address",
 				editEmail: "New email address",
 				placeholderMail: "xyz@ts.berlin",
 				password: "Password",
 				changePassword: "Change password",
+				passwordChangeConfirmation:
+					'Password changed, press "ok" to go to your profile',
 				deleteAccount: "Delete account",
 				approve: "Done",
 				checkInput: "Please check your input",
@@ -82,8 +86,12 @@ const en: Content = {
 				forgotYourPassword: "forgot your password?",
 				ohNoforgotYourPassword: "Oh no. You",
 				passwordForgotten: "Password forgotten",
+				resetPasswordEmailSent:
+					"Email sent! We sent you an email with a link to reset your password. Check your mailbox!",
 				clickHere: "click here",
 				resetPassword: "Reset password",
+				invalidCredentials: "Invalid credentials",
+				deleteAccountConfirm: "Are you sure you want to delete your account?",
 			},
 			logOut: "Log out",
 		},


### PR DESCRIPTION
fixes/features:
- removed early exits when response object `data` from supabase requests is null and when it is not directly used. In the supabase documentation, there is not defined why or what that means. Before i supposed that might be an error. But now I think we should just stick to make early exits when the `error` object is defined in supabase responses.

- added missing i18n
- added error handling for known/unknown errors in:
  - forgot-password submit
  - login submit
  - register submit
  - edit-email submit
  - edit-username submit
  - edit-password click
  - change-password submit
  - username-input-with-validation change
- i was getting confused the enable/disable conditions when editing email/username and tried to make the naming clearer
- made error messages isEmailTaken reset on component unmount to prevent showing it in a particular edge case (trying to register with email "x@y.z" which is already taken by another account, then login to this account, then directly try to change the e-mail)
- fixed wrong password regex


sorry for big PR. will definitely make smaller increments next time. 
