### PR TITLE
fix: too many last watered requests on tree click

### DIFF
--- a/src/components/tree-detail/tree-detail.tsx
+++ b/src/components/tree-detail/tree-detail.tsx
@@ -66,7 +66,6 @@ export const TreeDetail: React.FC = () => {
 					height={36}
 				/>
 				<div className="text-xl font-bold">{i18n.treeDetail.title}</div>
-				<div>hallo</div>
 			</div>
 			{treeData && (
 				<div className="flex flex-col">

--- a/src/components/tree-detail/tree-detail.tsx
+++ b/src/components/tree-detail/tree-detail.tsx
@@ -32,7 +32,8 @@ export const TreeDetail: React.FC = () => {
 	const { setTreeData } = useTreeStore();
 	const { setSelectedTreeId } = useSelectedTree();
 	const { treeData } = useFetchTreeData(treeId);
-	const { treeWateringData } = useFetchTreeWateringData(treeData);
+	const { treeWateringData, fetchWateringData } =
+		useFetchTreeWateringData(treeData);
 
 	const { treeAge, treeAgeClassification } = useTreeAgeClassification(treeData);
 	const treeTypeInfo = useMemo(() => {
@@ -65,6 +66,7 @@ export const TreeDetail: React.FC = () => {
 					height={36}
 				/>
 				<div className="text-xl font-bold">{i18n.treeDetail.title}</div>
+				<div>hallo</div>
 			</div>
 			{treeData && (
 				<div className="flex flex-col">
@@ -83,6 +85,9 @@ export const TreeDetail: React.FC = () => {
 							treeData={treeData}
 							treeAgeClassification={treeAgeClassification}
 							treeWateringData={treeWateringData}
+							onTreeWatered={async () => {
+								await fetchWateringData();
+							}}
 						/>
 					)}
 					{(treeAgeClassification === TreeAgeClassification.UNKNOWN ||
@@ -91,6 +96,9 @@ export const TreeDetail: React.FC = () => {
 							treeData={treeData}
 							treeAgeClassification={treeAgeClassification}
 							treeWateringData={treeWateringData}
+							onTreeWatered={async () => {
+								await fetchWateringData();
+							}}
 						/>
 					)}
 					{treeData && treeAgeClassification !== TreeAgeClassification.BABY && (

--- a/src/components/tree-detail/tree-water-need-unknown.tsx
+++ b/src/components/tree-detail/tree-water-need-unknown.tsx
@@ -14,12 +14,14 @@ interface TreeWaterNeedUnknownProps {
 	treeData: TreeData;
 	treeAgeClassification: TreeAgeClassification;
 	treeWateringData: TreeWateringData[];
+	onTreeWatered: () => void;
 }
 
 export const TreeWaterNeedUnknown: React.FC<TreeWaterNeedUnknownProps> = ({
 	treeData,
 	treeAgeClassification,
 	treeWateringData,
+	onTreeWatered,
 }) => {
 	const i18n = useI18nStore().i18n();
 	const { formatNumber } = useI18nStore();
@@ -129,6 +131,7 @@ export const TreeWaterNeedUnknown: React.FC<TreeWaterNeedUnknownProps> = ({
 					(
 						document.getElementById("water-dialog") as HTMLDialogElement
 					).close();
+					onTreeWatered();
 				}}
 			/>
 		</div>

--- a/src/components/tree-detail/tree-water-needs.tsx
+++ b/src/components/tree-detail/tree-water-needs.tsx
@@ -17,12 +17,14 @@ interface TreeWaterNeedProps {
 	treeData: TreeData;
 	treeAgeClassification: TreeAgeClassification;
 	treeWateringData: TreeWateringData[];
+	onTreeWatered: () => void;
 }
 
 export const TreeWaterNeed: React.FC<TreeWaterNeedProps> = ({
 	treeData,
 	treeAgeClassification,
 	treeWateringData,
+	onTreeWatered,
 }) => {
 	const i18n = useI18nStore().i18n();
 	const { formatNumber } = useI18nStore();
@@ -209,6 +211,7 @@ export const TreeWaterNeed: React.FC<TreeWaterNeedProps> = ({
 							(
 								document.getElementById("water-dialog") as HTMLDialogElement
 							).close();
+							onTreeWatered();
 						}}
 					/>
 				</div>

--- a/src/components/tree-detail/watering-dialog.tsx
+++ b/src/components/tree-detail/watering-dialog.tsx
@@ -1,12 +1,11 @@
+import { format, parse, parseISO } from "date-fns";
 import React, { useState } from "react";
+import { useI18nStore } from "../../i18n/i18n-store";
+import "../../index.css";
 import { PrimaryButton } from "../buttons/primary";
 import { SecondaryButton } from "../buttons/secondary";
-import { useFetchTreeWateringData } from "./hooks/use-fetch-tree-watering-data";
 import { useWaterTree } from "./hooks/use-water-tree";
 import { TreeData } from "./tree-types";
-import { format, parse, parseISO } from "date-fns";
-import "../../index.css";
-import { useI18nStore } from "../../i18n/i18n-store";
 
 interface WateringDialogProps {
 	treeData: TreeData;
@@ -21,7 +20,6 @@ export const WateringDialog: React.FC<WateringDialogProps> = ({
 	const dateFormat = "yyyy-MM-dd'T'hh:mm";
 
 	const { waterTree } = useWaterTree(treeData.id);
-	const { fetchWateringData } = useFetchTreeWateringData(treeData);
 	const [amount, setAmount] = useState(0);
 	const [waterDate, setWaterDate] = useState(new Date());
 
@@ -70,7 +68,6 @@ export const WateringDialog: React.FC<WateringDialogProps> = ({
 						disabled={false}
 						onClick={async () => {
 							await waterTree(amount, waterDate);
-							await fetchWateringData();
 							close();
 						}}
 					/>


### PR DESCRIPTION
Previously, two network requests to "lastwatered" endpoint were made when tree detail view was opened, although only one is necessary. 