### PR TITLE
fix: viewport mobile, filter mobile, clear icon

### DIFF
--- a/src/components/buttons/primary.tsx
+++ b/src/components/buttons/primary.tsx
@@ -16,7 +16,7 @@ export const PrimaryButton: React.FC<PrimaryButtonProps> = ({
 	return (
 		<button
 			className={`
-      my-4 flex h-[51px] w-full items-center justify-center rounded-[10px] bg-gdk-blue px-8 font-semibold 
+      my-2 lg:my-4 flex h-[51px] w-full items-center justify-center rounded-[10px] bg-gdk-blue px-8 font-semibold 
       text-gdk-white hover:bg-gdk-light-blue disabled:bg-gdk-light-gray sm:w-fit`}
 			disabled={disabled}
 			onClick={onClick}

--- a/src/components/buttons/secondary.tsx
+++ b/src/components/buttons/secondary.tsx
@@ -15,7 +15,7 @@ export const SecondaryButton: React.FC<SecondaryButtonProps> = ({
 		<button
 			className={`bg-gdk-white outline-gdk-blue text-gdk-blue enabled:hover:bg-gdk-light-blue hover:text-gdk-white 
       disabled:outline-gdk-light-gray disabled:text-gdk-light-gray  
-       my-4 flex  h-[51px] w-fit items-center justify-center rounded-[10px] px-8 py-3.5 font-semibold outline outline-2`}
+	  my-2 lg:my-4 flex  h-[51px] w-fit items-center justify-center rounded-[10px] px-8 py-3.5 font-semibold outline outline-2`}
 			disabled={disabled}
 			onClick={onClick}
 		>

--- a/src/components/filter/filter-switch.tsx
+++ b/src/components/filter/filter-switch.tsx
@@ -13,8 +13,8 @@ export const FilterSwitch: React.FC<FilterSwitchProps> = ({
 	isEnabled,
 }) => {
 	return (
-		<div className="w-full flex flex-row items-center justify-between p-4 border-2 rounded-lg bg-[#FAFAFA] border-[#DDDDDD]">
-			<div className="text-lg font-semibold">{name}</div>
+		<div className="w-full flex flex-row items-center justify-between py-2 px-4 lg:p-4 border-2 rounded-lg bg-[#FAFAFA] border-[#DDDDDD]">
+			<div className="text-base lg:text-lg font-semibold">{name}</div>
 			<div>
 				<SwitchButton onToggle={onToggle} isEnabled={isEnabled} />
 			</div>

--- a/src/components/filter/filter.tsx
+++ b/src/components/filter/filter.tsx
@@ -41,7 +41,7 @@ export const Filter: React.FC<FilterProps> = ({ onFilterChange }) => {
 	return (
 		<div className="flex flex-row w-full justify-center pointer-events-auto">
 			<div
-				className={`flex flex-col lg:drop-shadow-md bg-white rounded-lg p-4 lg:p-6 gap-6 w-full`}
+				className={`flex flex-col lg:drop-shadow-md bg-white rounded-lg px-4 pt-2 pb-0 lg:p-4 lg:p-6 gap-2 lg:gap-6 w-full`}
 			>
 				<div className="flex flex-col gap-2">
 					<div className="font-bold text-xl">{i18n.filter.title}</div>

--- a/src/components/filter/tree-age-button.tsx
+++ b/src/components/filter/tree-age-button.tsx
@@ -18,7 +18,7 @@ export const TreeAgeButton: React.FC<TreeAgeButtonProps> = ({
 		<div
 			className={`${
 				interval.enabled && "border-gdk-blue"
-			} border-2 h-full flex flex-col justify-center text-center p-2 rounded-lg bg-[#F7F7F7] hover:cursor-pointer gap-2 p-3`}
+			} border-2 h-full flex flex-col justify-center text-center p-2 rounded-lg bg-[#F7F7F7] hover:cursor-pointer gap-2`}
 			onClick={() => {
 				onChange(interval);
 			}}

--- a/src/components/location-search/location-search.tsx
+++ b/src/components/location-search/location-search.tsx
@@ -124,7 +124,10 @@ export const LocationSearch: React.FC<LocationSearchProps> = ({
 						}}
 						placeholder={i18n.locationSearch.placeholder}
 					/>
-					<button className="px-4" onClick={clearSearch}>
+					<button
+						className={`${search === "" && "opacity-0"} px-4`}
+						onClick={clearSearch}
+					>
 						<ClearIcon />
 					</button>
 				</form>

--- a/src/components/router/router.tsx
+++ b/src/components/router/router.tsx
@@ -30,7 +30,7 @@ export const Router: React.FC = () => {
 		case "/map":
 			return (
 				<div
-					className={`flex h-screen w-screen flex-col-reverse justify-between lg:flex-row ${
+					className={`flex h-dvh w-screen flex-col-reverse justify-between lg:flex-row ${
 						treeId && "bg-white"
 					} lg:bg-transparent`}
 				>
@@ -76,28 +76,28 @@ export const Router: React.FC = () => {
 			);
 		case "/profile/reset-password":
 			return (
-				<div className="pointer-events-auto flex h-screen w-screen flex-col-reverse justify-between bg-white lg:flex-row">
+				<div className="pointer-events-auto flex h-dvh w-screen flex-col-reverse justify-between bg-white lg:flex-row">
 					<Navbar />
 					<PasswordReset />
 				</div>
 			);
 		case "/profile":
 			return (
-				<div className="pointer-events-auto flex h-screen w-screen flex-col-reverse justify-between bg-white lg:flex-row">
+				<div className="pointer-events-auto flex h-dvh w-screen flex-col-reverse justify-between bg-white lg:flex-row">
 					<Navbar />
 					<Profile />
 				</div>
 			);
 		case "/about":
 			return (
-				<div className="flex h-screen w-screen flex-col-reverse bg-white lg:flex-row">
+				<div className="flex h-dvh w-screen flex-col-reverse bg-white lg:flex-row">
 					<Navbar />
 					<Info />
 				</div>
 			);
 		default:
 			return (
-				<div className="flex h-screen w-screen flex-col-reverse bg-white lg:flex-row">
+				<div className="flex h-dvh w-screen flex-col-reverse bg-white lg:flex-row">
 					<Navbar />
 					<PageNotFound />
 				</div>


### PR DESCRIPTION
- On real mobile, the viewport was wrong
- and the filter did not fit on the screen.
- clear icon is now shown only when search string is not empty

TIL

> [Dynamic viewport height](https://tailwindcss.com/docs/height#dynamic-viewport-height)
Use h-dvh to make an element span the entire height of the viewport, which changes as the browser UI expands or contracts.