### PR TITLE
Feat/fix zoom in on input

### DIFF
--- a/src/components/input/text-input.tsx
+++ b/src/components/input/text-input.tsx
@@ -7,7 +7,7 @@ export const TextInput: React.FC<
 		<input
 			className={`
         border-input bg-background placeholder:text-muted-foreground my-2 flex h-[51px] w-full flex-auto 
-        rounded-2xl  border px-3 py-2 text-sm outline-1 focus:outline-2
+        rounded-2xl border px-3 py-2 outline-1 focus:outline-2
         focus:outline-gdk-blue disabled:cursor-not-allowed disabled:opacity-50
       `}
 			{...props}


### PR DESCRIPTION
On Safari Mobile, when the input field text size is smaller than 16px, then there is a zoom in. We can prevent this by using a bigger font-size.