### PR TITLE
fix: replace controlled inputs in watering dialog with form

### DIFF
--- a/src/components/buttons/secondary.tsx
+++ b/src/components/buttons/secondary.tsx
@@ -4,12 +4,14 @@ export interface SecondaryButtonProps {
 	label: string | React.ReactNode;
 	onClick: () => void;
 	disabled?: boolean;
+	type?: "button" | "submit";
 }
 
 export const SecondaryButton: React.FC<SecondaryButtonProps> = ({
 	label,
 	onClick,
 	disabled,
+	type = "button",
 }) => {
 	return (
 		<button
@@ -18,6 +20,7 @@ export const SecondaryButton: React.FC<SecondaryButtonProps> = ({
 	  my-2 lg:my-4 flex  h-[51px] w-fit items-center justify-center rounded-[10px] px-8 py-3.5 font-semibold outline outline-2`}
 			disabled={disabled}
 			onClick={onClick}
+			type={type}
 		>
 			<span className="flex flex-row  items-center gap-3">{label}</span>
 		</button>

--- a/src/components/profile/profile-alert/alert-dialog.tsx
+++ b/src/components/profile/profile-alert/alert-dialog.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useI18nStore } from "../../../i18n/i18n-store.ts";
-import { PrimaryButton } from "../../buttons/primary.tsx";
+import { PrimaryButton } from "../../buttons/primary";
 import { useUrlState } from "../../router/store";
 
 export interface AlertDialogProps {

--- a/src/components/tree-detail/hooks/use-fetch-tree-data.tsx
+++ b/src/components/tree-detail/hooks/use-fetch-tree-data.tsx
@@ -36,6 +36,10 @@ export function useFetchTreeData(treeId: string | undefined): TreeDataState {
 				const json = await res.json();
 				setTreeData(json.data[0]);
 			} catch (error) {
+				if (abortController.signal.aborted) {
+					return;
+				}
+
 				handleError(i18n.common.defaultErrorMessage, error);
 			}
 		};

--- a/src/components/tree-detail/hooks/use-water-tree.tsx
+++ b/src/components/tree-detail/hooks/use-water-tree.tsx
@@ -23,6 +23,7 @@ export function useWaterTree(treeId: string): WaterTreeState {
 		if (!user?.id) {
 			return;
 		}
+
 		try {
 			setWateringLoading(true);
 			const adoptUrl = `${import.meta.env.VITE_API_ENDPOINT}/post/water`;


### PR DESCRIPTION
I replaced the controlled inputs with a form to have some basic validation, e.g. water amount >= 1, date <= today. I also added a numeric input mode for easier input on mobile:

![simulator_screenshot_9ACD5C0D-74B6-465C-A183-A92B439DEB9C](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/76ad26d3-fbcf-4a80-8c07-94f876994076)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206727518885048