### PR TITLE
feat: zoom in to tree when map loaded

### DIFF
--- a/src/components/map/hooks/use-map-trees-interaction.tsx
+++ b/src/components/map/hooks/use-map-trees-interaction.tsx
@@ -47,6 +47,23 @@ export function useMapTreesInteraction(map: mapboxgl.Map | undefined) {
 
 	useEffect(() => {
 		if (treeData) {
+			if (map?.loaded()) {
+				setSelectedTreeId(treeData.id);
+				map.setFeatureState(
+					{
+						id: treeData.id,
+						source: "trees",
+						sourceLayer: "trees",
+					},
+					{ select: true },
+				);
+				map.easeTo({
+					center: [parseFloat(treeData.lat), parseFloat(treeData.lng)],
+					zoom: MAP_MAX_ZOOM_LEVEL,
+					essential: true,
+				});
+				return;
+			}
 			map?.on("load", () => {
 				setSelectedTreeId(treeData.id);
 				map.setFeatureState(


### PR DESCRIPTION
this allows the zoom in after clicking on an adopted tree in profile