### PR TITLE
fix: remove argument from use-geocoding hook call

### DIFF
--- a/src/components/location-search/hooks/use-geocoding.tsx
+++ b/src/components/location-search/hooks/use-geocoding.tsx
@@ -11,10 +11,10 @@ export interface GeocodingResult {
 export interface GeocodingResultState {
 	geocodingResults: GeocodingResult[];
 	clearGeocodingResults: () => void;
-	fetchGeocodingResults: () => void;
+	fetchGeocodingResults: (search: string) => void;
 }
 
-export function useGeocoding(search: string): GeocodingResultState {
+export function useGeocoding(): GeocodingResultState {
 	const [geocodingResults, setGeocodingResults] = useState<GeocodingResult[]>(
 		[],
 	);
@@ -23,13 +23,11 @@ export function useGeocoding(search: string): GeocodingResultState {
 		setGeocodingResults([]);
 	};
 
-	const fetchGeocodingResults = async () => {
+	const fetchGeocodingResults = async (search: string) => {
 		if (search.trim().length < 2) {
 			setGeocodingResults([]);
-			return () => {};
+			return;
 		}
-
-		const abortController = new AbortController();
 
 		const fetchData = async () => {
 			try {
@@ -38,9 +36,7 @@ export function useGeocoding(search: string): GeocodingResultState {
 				}/geocoding/v5/mapbox.places/${search}.json?autocomplete=true&language=de&country=de&bbox=${
 					import.meta.env.VITE_MAP_BOUNDING_BOX
 				}&access_token=${import.meta.env.VITE_MAPBOX_API_KEY}`;
-				const res = await fetch(geocodingUrl, {
-					signal: abortController.signal,
-				});
+				const res = await fetch(geocodingUrl);
 				if (!res.ok) {
 					return;
 				}
@@ -52,10 +48,6 @@ export function useGeocoding(search: string): GeocodingResultState {
 		};
 
 		fetchData().catch(console.error);
-
-		return () => {
-			abortController.abort();
-		};
 	};
 
 	return { geocodingResults, clearGeocodingResults, fetchGeocodingResults };

--- a/src/components/location-search/location-search.tsx
+++ b/src/components/location-search/location-search.tsx
@@ -16,7 +16,6 @@ export const LocationSearch: React.FC = () => {
 	const { toggleFilterView, hideFilterView } = useFilterStore();
 
 	const {
-		isCurrentSearch,
 		setIsCurrentSearch,
 		isPickedGeoSearchResult,
 		setisPickedGeoSearchResult,
@@ -32,7 +31,7 @@ export const LocationSearch: React.FC = () => {
 	const { map } = useMapStore();
 	const { MAP_LOCATION_ZOOM_LEVEL } = useMapConstants();
 	const { geocodingResults, clearGeocodingResults, fetchGeocodingResults } =
-		useGeocoding(isCurrentSearch);
+		useGeocoding();
 	const { isFilterViewVisible, isSomeFilterActive } = useFilterStore();
 
 	const clearSearchAndGeocodingResults = () => {
@@ -127,7 +126,7 @@ export const LocationSearch: React.FC = () => {
 							setIsCurrentSearch(e.target.value);
 							setisPickedGeoSearchResult(e.target.value);
 							setSelectedGeocodingResult(undefined);
-							fetchGeocodingResults();
+							fetchGeocodingResults(e.target.value);
 							setIsTextInSearchbar(true);
 						}}
 						onFocus={() => {


### PR DESCRIPTION
 remove argument from use-geocoding hook call and move to fetch geocoding results call to prevent that the fetch gets called with the previous value instead of the current value

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206979616697418