### PR TITLE
feat: add listener for map idle

### DIFF
--- a/src/components/map/hooks/use-map-pumps-interaction.tsx
+++ b/src/components/map/hooks/use-map-pumps-interaction.tsx
@@ -33,6 +33,7 @@ export function useMapPumpsInteraction(map: mapboxgl.Map | undefined) {
 		if (!map) {
 			return;
 		}
+
 		if (map.isStyleLoaded()) {
 			map.setLayoutProperty(
 				"pumps",
@@ -45,11 +46,26 @@ export function useMapPumpsInteraction(map: mapboxgl.Map | undefined) {
 				isPumpsVisible ? "visible" : "none",
 			);
 		}
+
+		map.once("idle", () => {
+			map.setLayoutProperty(
+				"pumps",
+				"visibility",
+				isPumpsVisible ? "visible" : "none",
+			);
+			map.setLayoutProperty(
+				"pumps-highlight",
+				"visibility",
+				isPumpsVisible ? "visible" : "none",
+			);
+		});
+
 		if (!isPumpsVisible) {
 			setHoveredPump(undefined);
 			setSelectedPump(undefined);
 		}
 	}, [map, isPumpsVisible]);
+
 	useEffect(() => {
 		if (!map) {
 			return;


### PR DESCRIPTION
I added map.once("idle"
which fires when everything has been rendered on the map.

I kept map.isStyleLoaded() to avoid a long loading state for the pumps, when only the pumps are toggled. 

So either the pump layer is set to visible if the style is loaded quickly enough otherwise the pumps are set to visible when the idle state is reached.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206980650488442