### PR TITLE
fix: hide also adopted by others when the only adopter is the user themself

### DIFF
--- a/src/components/tree-detail/tree-adopt-card.tsx
+++ b/src/components/tree-detail/tree-adopt-card.tsx
@@ -20,9 +20,9 @@ export const TreeAdoptCard: React.FC<TreeAdoptCardProps> = ({
 	const [showTooltip, setShowTooltip] = useState(false);
 	const i18n = useI18nStore().i18n();
 
-	const { isAdopted, isLoading, adoptedByOthers } = useTreeAdoptStore();
+	const { isAdopted, isLoading, amountOfAdoptions } = useTreeAdoptStore();
 
-	const isTreeAdopted = isAdopted(treeData.id);
+	const isTreeAdoptedByUser = isAdopted(treeData.id);
 
 	const isLoggedIn = useAuthStore().isLoggedIn();
 
@@ -32,17 +32,22 @@ export const TreeAdoptCard: React.FC<TreeAdoptCardProps> = ({
 		}
 
 		if (isLoading) {
-			if (isTreeAdopted) {
+			if (isTreeAdoptedByUser) {
 				return i18n.treeDetail.unadoptLoading;
 			}
 			return i18n.treeDetail.adoptLoading;
 		}
 
-		if (isTreeAdopted) {
+		if (isTreeAdoptedByUser) {
 			return i18n.treeDetail.isAdopted;
 		}
 		return i18n.treeDetail.adoptIt;
-	}, [isLoading, isTreeAdopted, i18n]);
+	}, [isLoading, isTreeAdoptedByUser, i18n]);
+
+	const isTreeAlsoAdoptedByOthers =
+		amountOfAdoptions > 1 && isTreeAdoptedByUser;
+	const isTreeOnlyAdoptedByOthers =
+		amountOfAdoptions > 0 && !isTreeAdoptedByUser;
 
 	return (
 		<div className="shadow-gdk-hard flex flex-col gap-4 rounded-lg bg-slate-100 p-4">
@@ -87,7 +92,7 @@ export const TreeAdoptCard: React.FC<TreeAdoptCardProps> = ({
 						)}
 					</div>
 				</div>
-				{adoptedByOthers && !isTreeAdopted && (
+				{isTreeOnlyAdoptedByOthers && (
 					<div className="items-left flex flex-row gap-2">
 						<img
 							src="/images/hi-there-icon.svg"
@@ -96,11 +101,11 @@ export const TreeAdoptCard: React.FC<TreeAdoptCardProps> = ({
 							height={24}
 						/>
 						<div className="italic leading-tight text-slate-500">
-							{i18n.treeDetail.adoptedByOtherUsers}
+							{i18n.treeDetail.onlyAdoptedByOtherUsers}
 						</div>
 					</div>
 				)}
-				{adoptedByOthers && isTreeAdopted && (
+				{isTreeAlsoAdoptedByOthers && (
 					<div className="items-left flex flex-row gap-2">
 						<img
 							src="/images/hi-there-icon.svg"

--- a/src/i18n/content-types.ts
+++ b/src/i18n/content-types.ts
@@ -208,7 +208,7 @@ interface TreeDetail {
 	title: string;
 	adoptIt: string;
 	alsoAdoptedByOtherUsers: string;
-	adoptedByOtherUsers: string;
+	onlyAdoptedByOtherUsers: string;
 	adoptLoading: string;
 	unadoptLoading: string;
 	isAdopted: string;

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -257,7 +257,7 @@ Die Straßen- und Grünflächenämter sind bereits aktiv, kommen allerdings mit 
 		title: "Bauminformationen",
 		adoptIt: "Diesen Baum adoptieren",
 		alsoAdoptedByOtherUsers: "Auch von anderen User:innen adoptiert",
-		adoptedByOtherUsers: "Von anderen User:innen adoptiert",
+		onlyAdoptedByOtherUsers: "Von anderen User:innen adoptiert",
 		adoptLoading: "Baum wird adoptiert...",
 		unadoptLoading: "Adoption wird aufgehoben...",
 		isAdopted: "Du hast diesen Baum adoptiert",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -257,7 +257,7 @@ Use via smartphone (mobile network) can lead to performance problems (page loads
 		title: "Tree information",
 		adoptIt: "Adopt this tree",
 		alsoAdoptedByOtherUsers: "Also adopted by other users",
-		adoptedByOtherUsers: "Adopted by other users",
+		onlyAdoptedByOtherUsers: "Adopted by other users",
 		ageTitle: "Age",
 		adoptLoading: "Tree is being adopted...",
 		unadoptLoading: "Adoption is being canceled...",


### PR DESCRIPTION
There was a bug showing the label `also adopted by others` when the user was the sole adopter of a tree.

![Bildschirmfoto 2024-04-22 um 18 29 16](https://github.com/technologiestiftung/giessdenkiez-de/assets/8709861/0ef2ef18-f238-4e16-b867-f8d26cc94d53)

This PR fixes this and hides this label when the user is the sole adopter of a tree. Also refactored a few names in an attempt to bring more clarity.