### PR TITLE
fix: error when watering after logging-in

### DIFF
--- a/src/components/tree-detail/hooks/use-water-tree.tsx
+++ b/src/components/tree-detail/hooks/use-water-tree.tsx
@@ -17,7 +17,7 @@ export function useWaterTree(): WaterTreeState {
 
 	const access_token = useAuthStore((store) => store).session?.access_token;
 	const user = useAuthStore((store) => store).session?.user;
-	const { username, refreshUserWaterings } = useProfileStore();
+	const { refreshUserWaterings } = useProfileStore();
 	const { refreshTreeWateringData } = useTreeStore();
 
 	const abortController = new AbortController();
@@ -29,6 +29,7 @@ export function useWaterTree(): WaterTreeState {
 		}
 
 		const treeId = useTreeStore.getState().selectedTreeId;
+		const username = useProfileStore.getState().username;
 
 		if (!treeId) {
 			return;

--- a/src/shared-stores/profile-store.tsx
+++ b/src/shared-stores/profile-store.tsx
@@ -51,7 +51,7 @@ export const useProfileStore = create<ProfileStore>()((set, get) => ({
 	refresh: async () => {
 		const promises = [
 			get().refreshUsername(),
-			get().refreshAdoptedTrees(),
+			get().refreshAdoptedTreesInfo(),
 			get().refreshUserWaterings(),
 		];
 
@@ -60,6 +60,12 @@ export const useProfileStore = create<ProfileStore>()((set, get) => ({
 
 	username: null,
 	refreshUsername: async () => {
+		set({ username: null });
+
+		if (!useAuthStore.getState().isLoggedIn()) {
+			return;
+		}
+
 		const { data, error } = await supabaseClient
 			.from("profiles")
 			.select("username")
@@ -85,6 +91,12 @@ export const useProfileStore = create<ProfileStore>()((set, get) => ({
 
 	adoptedTrees: [],
 	refreshAdoptedTrees: async () => {
+		set({ adoptedTrees: [] });
+
+		if (!useAuthStore.getState().isLoggedIn()) {
+			return;
+		}
+
 		const { data, error } = await supabaseClient
 			.from("trees_adopted")
 			.select("tree_id")
@@ -107,6 +119,8 @@ export const useProfileStore = create<ProfileStore>()((set, get) => ({
 
 	adoptedTreesInfo: null,
 	refreshAdoptedTreesInfo: async () => {
+		set({ adoptedTreesInfo: null });
+
 		await get().refreshAdoptedTrees();
 
 		const { data, error } = await supabaseClient
@@ -167,6 +181,12 @@ export const useProfileStore = create<ProfileStore>()((set, get) => ({
 		return { totalWateringVolume, totalWateringCount };
 	},
 	refreshUserWaterings: async () => {
+		set({ userWaterings: null });
+
+		if (!useAuthStore.getState().isLoggedIn()) {
+			return;
+		}
+
 		const userId = useAuthStore.getState().session?.user.id;
 		const accessToken = useAuthStore.getState().session?.access_token;
 


### PR DESCRIPTION
the username was`null` in waterTree(), due to the function being created with a previous state, and not being up-to-date with the current state during execution.

-> get username inside waterTree() instead of outside