### PR TITLE
Fix/legend and bar chart

### DIFF
--- a/src/components/filter/age-range-slider/bar-graph.tsx
+++ b/src/components/filter/age-range-slider/bar-graph.tsx
@@ -20,7 +20,7 @@ export const BarGraph: React.FC<BarGraphProps> = ({ min, max }) => {
 			isActive: ageGroup.alter >= min && ageGroup.alter <= max,
 			barPercentage: calculateBarPercentage(ageGroup.count, MAX_COUNT),
 			id: ageGroup.alter,
-		}));
+		})).reverse();
 	}, [min, max]);
 
 	const yAxisLabelHeight = calculateBarPercentage(100000, MAX_COUNT);
@@ -35,7 +35,7 @@ export const BarGraph: React.FC<BarGraphProps> = ({ min, max }) => {
 				<span className="text-[#DDDDDD] -translate-y-0.5 font-semibold absolute right-0">
 					100k
 				</span>
-				{barItems.reverse().map((ageGroup) => (
+				{barItems.map((ageGroup) => (
 					<BarItem
 						key={ageGroup.id}
 						barPercentage={ageGroup.barPercentage}

--- a/src/components/legend/legend.tsx
+++ b/src/components/legend/legend.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { LegendButton } from "../buttons/legend-button";
+import { useSplashStore } from "../splash/splash-store";
+import { useTreeStore } from "../tree-detail/stores/tree-store";
+import { useFilterStore } from "../filter/filter-store";
+import { useMapStore } from "../map/map-store";
+
+export const Legend: React.FC = () => {
+	const { isSplashScreenVisible } = useSplashStore();
+	const { selectedTreeId } = useTreeStore();
+	const { isFilterViewVisible } = useFilterStore();
+	const { isMapLoaded } = useMapStore();
+
+	const isLegendVisibleDesktop =
+		!isSplashScreenVisible() && !selectedTreeId && isMapLoaded;
+	const isLegendVisibleMobile = isLegendVisibleDesktop && !isFilterViewVisible;
+
+	return (
+		<div
+			className={`
+			absolute left-[10px] bottom-[175px] md:bottom-[306px] lg:bottom-[242px] lg:left-[90px]
+		 	${isLegendVisibleMobile ? "block" : "hidden"}
+		 	${isLegendVisibleDesktop ? "sm:block" : "sm:hidden"}
+			`}
+		>
+			<LegendButton />
+		</div>
+	);
+};

--- a/src/components/router/router.tsx
+++ b/src/components/router/router.tsx
@@ -13,8 +13,8 @@ import { useLocationEventListener } from "./hooks/use-location-event-listener";
 import { useUrlState } from "./store";
 import { Splash } from "../splash/splash";
 import { useMapStore } from "../map/map-store";
-import { LegendButton } from "../buttons/legend-button";
 import { useSplashStore } from "../splash/splash-store";
+import { Legend } from "../legend/legend";
 
 export const Router: React.FC = () => {
 	const url = useUrlState((state) => state.url);
@@ -48,40 +48,34 @@ export const Router: React.FC = () => {
 					<div
 						className={`${isFilterViewVisible && "bg-white rounded-t-lg sm:bg-transparent"}`}
 					>
-						<div className={`${treeId ? "hidden" : "block sm:hidden"}`}>
+						<div
+							className={`${treeId ? "hidden" : "block sm:hidden max-h-[calc(100svh-150px)] overflow-y-auto"}`}
+						>
 							{isFilterViewVisible && <Filter />}
 						</div>
 						<Navbar />
 					</div>
 
 					{!isSplashScreenVisible() && isMapLoaded && (
-						<>
-							<div className="mt-3 flex w-full flex-row justify-center">
-								<div
-									className={`${
-										treeId ? "w-[100%] sm:w-[400px]" : "w-[100%] sm:w-[500px]"
-									} flex flex-col gap-4`}
-								>
-									<div className={`${treeId && "hidden lg:flex"}`}>
-										<LocationSearch />
-									</div>
+						<div className="mt-3 flex w-full flex-row justify-center">
+							<div
+								className={`${
+									treeId ? "w-[100%] sm:w-[400px]" : "w-[100%] sm:w-[500px]"
+								} flex flex-col gap-4`}
+							>
+								<div className={`${treeId && "hidden lg:flex"}`}>
+									<LocationSearch />
+								</div>
 
-									<div
-										className={`${treeId ? "hidden lg:flex" : "hidden sm:flex"}`}
-									>
-										{isFilterViewVisible && <Filter />}
-									</div>
+								<div
+									className={`${treeId ? "hidden lg:flex" : "hidden sm:flex"}`}
+								>
+									{isFilterViewVisible && <Filter />}
 								</div>
 							</div>
-
-							<div
-								className={`left-[10px] bottom-[175px] absolute
-							md:bottom-[306px] lg:bottom-[242px] lg:left-[90px] ${(treeId || isFilterViewVisible) && "hidden lg:block"}`}
-							>
-								<LegendButton />
-							</div>
-						</>
+						</div>
 					)}
+					<Legend />
 					{treeId && isMapLoaded && <TreeDetail />}
 					{isSplashScreenVisible() && <Splash />}
 				</div>


### PR DESCRIPTION
This PR fixes:
- the position of the legend (e.g. hides it when the filter view is open)
- the bug where the bar chart filter bars get reversed when resetting