### PR TITLE
fix: barchart height

### DIFF
--- a/src/components/filter/age-range-slider/bar-graph.tsx
+++ b/src/components/filter/age-range-slider/bar-graph.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { BarItem } from "./bar-item";
 import { getMaxCount, getTreesGroupByAge } from "./tree-age-grouped";
+import { useBarGraphHeight } from "./hooks/use-bar-graph-height.tsx";
 
 const TREES_GROUPED_BY_AGE = getTreesGroupByAge();
 const MAX_COUNT = getMaxCount();
@@ -25,14 +26,18 @@ export const BarGraph: React.FC<BarGraphProps> = ({ min, max }) => {
 
 	const yAxisLabelHeight = calculateBarPercentage(100000, MAX_COUNT);
 
+	const { height, translateYAxisIndicator } = useBarGraphHeight();
+
 	return (
-		<div className="w-full h-[90px] relative">
+		<div className="w-full relative" style={{ height: height }}>
 			<div className="flex flex-row gap-0.5 w-full h-full">
 				<div
 					className="w-full border border-[#DDDDDD] z-0 absolute"
 					style={{ bottom: yAxisLabelHeight }}
 				></div>
-				<span className="text-[#DDDDDD] -translate-y-0.5 font-semibold absolute right-0">
+				<span
+					className={`${translateYAxisIndicator} text-[#DDDDDD] font-semibold absolute right-0`}
+				>
 					100k
 				</span>
 				{barItems.map((ageGroup) => (

--- a/src/components/filter/age-range-slider/hooks/use-bar-graph-height.tsx
+++ b/src/components/filter/age-range-slider/hooks/use-bar-graph-height.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+
+export function useBarGraphHeight() {
+	const [height, setHeight] = useState(0);
+	const [translateYAxisIndicator, setTranslateYAxisIndicator] = useState("");
+	useEffect(() => {
+		const handleResize = () => {
+			const newBarGraphHeight = getBarGraphHeight(window.innerHeight);
+			setHeight(newBarGraphHeight);
+			setTranslateYAxisIndicator(getTranslateYAxisIndicator(newBarGraphHeight));
+		};
+
+		// Create a new ResizeObserver
+		const resizeObserver = new ResizeObserver(handleResize);
+
+		// Observe when document.body resizes
+		resizeObserver.observe(document.body);
+
+		// Cleanup function to remove the observer when component unmounts
+		return () => {
+			resizeObserver.disconnect();
+		};
+	}, []);
+
+	return { height, translateYAxisIndicator };
+}
+
+function getBarGraphHeight(innerHeight: number) {
+	if (innerHeight < 600) {
+		return 20;
+	}
+
+	if (innerHeight < 650) {
+		return 40;
+	}
+
+	if (innerHeight < 700) {
+		return 60;
+	}
+
+	return 90;
+}
+
+function getTranslateYAxisIndicator(height: number) {
+	switch (height) {
+		case 20:
+			return "-translate-y-[1.125rem]";
+		case 40:
+			return "-translate-y-3";
+		case 60:
+			return "-translate-y-2";
+		default:
+			return "-translate-y-0.5";
+	}
+}

--- a/src/components/router/router.tsx
+++ b/src/components/router/router.tsx
@@ -49,7 +49,9 @@ export const Router: React.FC = () => {
 						className={`${isFilterViewVisible && "bg-white rounded-t-lg sm:bg-transparent"}`}
 					>
 						<div
-							className={`${treeId ? "hidden" : "block sm:hidden max-h-[calc(100svh-150px)] overflow-y-auto"}`}
+							className={
+								treeId ? "hidden" : "block sm:hidden max-h-[calc(100svh-150px)]"
+							}
 						>
 							{isFilterViewVisible && <Filter />}
 						</div>


### PR DESCRIPTION
~adding webkit-overflow-scrolling to filter view to fix the bug where you could not scroll the filter view on mobiles with very small height~


~edit: is just a test / draft needs to be approved from PO~

this PR now makes the bar chart change its height depending on the viewport height