### PR TITLE
Fix/jumpy map after zoom

### DIFF
--- a/src/components/map/hooks/use-map-trees-interaction.tsx
+++ b/src/components/map/hooks/use-map-trees-interaction.tsx
@@ -124,6 +124,8 @@ export function useMapTreesInteraction(map: mapboxgl.Map | undefined) {
 		}
 		map.on("zoomend", () => {
 			setZoom(map.getZoom());
+			setLat(map.getCenter().lat);
+			setLng(map.getCenter().lng);
 		});
 		map.on("moveend", () => {
 			setLat(map.getCenter().lat);


### PR DESCRIPTION
fixes the bug on mobile, when you pinch to zoom, the map jumps sometimes a bit around on zoom end. This is because `zoomend` used to only set the zoom in the state. However, mapbox can zoom+pan at the same time, which means that using pinch to zoom also slightly moves the center of the map, which then gets not updated correctly in the state