### PR TITLE
feat: add debounce when writing to url

### DIFF
--- a/src/components/router/store.tsx
+++ b/src/components/router/store.tsx
@@ -15,6 +15,8 @@ interface URLState {
 	removeSearchParam: (keyToRemove: string) => void;
 }
 
+let debounceTimeoutId: ReturnType<typeof setTimeout>;
+
 export const useUrlState = create<URLState>()((set, get) => ({
 	url: new URL(window.location.href),
 
@@ -44,8 +46,12 @@ export const useUrlState = create<URLState>()((set, get) => ({
 
 		set({ url });
 
-		window.history.pushState({}, "", url);
-		trackPageView();
+		clearTimeout(debounceTimeoutId);
+
+		debounceTimeoutId = setTimeout(() => {
+			window.history.pushState({}, "", url);
+			trackPageView();
+		}, 500);
 	},
 
 	addSearchParam: (key: string, value: string) => {


### PR DESCRIPTION
 added debounce when writing to url, this prevents the error `SecurityError: Attempt to use history.pushState() more than 100 times per 10 seconds` which crashes the website