### PR TITLE
feat: age classification per district

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ff6347 @raphael-arce @Jaszkowic @vogelino @aeschi
+* @raphael-arce @Jaszkowic @vogelino @aeschi

--- a/.github/workflows/rain.yml
+++ b/.github/workflows/rain.yml
@@ -19,7 +19,7 @@ jobs:
     name: Aggregate rain data from DWD radolan
     steps:
       - name: Harvester
-        uses: docker://technologiestiftung/giessdenkiez-de-dwd-harvester:v2.6.0
+        uses: docker://technologiestiftung/giessdenkiez-de-dwd-harvester:v2.7.0
         id: harvester
         env:
           PG_SERVER: ${{ secrets.PG_SERVER }}

--- a/src/components/map/hooks/use-tree-circle-style.tsx
+++ b/src/components/map/hooks/use-tree-circle-style.tsx
@@ -91,9 +91,32 @@ export function useTreeCircleStyle() {
 			"case",
 			["==", ["get", "age"], ""],
 			TREE_DEFAULT_COLOR,
-			[">", ["get", "age"], 10],
+			[
+				">",
+				["get", "age"],
+				// TODO: by district here
+				[
+					"case",
+					["==", ["get", "district"], "Neukölln"],
+					10,
+					["==", ["get", "district"], "Pankow"],
+					12,
+					5,
+				],
+			],
 			TREE_DEFAULT_COLOR, // Color for trees older than 10 years
-			[">=", ["get", "age"], 5],
+			[
+				">=",
+				["get", "age"],
+				[
+					"case",
+					["==", ["get", "district"], "Neukölln"],
+					10,
+					["==", ["get", "district"], "Pankow"],
+					12,
+					5,
+				],
+			],
 			[
 				"case",
 				[

--- a/src/components/map/hooks/use-tree-circle-style.tsx
+++ b/src/components/map/hooks/use-tree-circle-style.tsx
@@ -89,45 +89,14 @@ export function useTreeCircleStyle() {
 	}): Expression => {
 		const defaultExpression: Expression = [
 			"case",
-			["in", ["get", "district"], "Mitte", "Pankow", "Neukölln", "Lichtenberg"],
 
-			// Define logic for "special" districts
+			// Define logic for "special" districts, those are always rendered in default color
 			[
-				"case",
-
-				// Fall back to default color for trees with undefined age
-				["==", ["get", "age"], ""],
-				TREE_DEFAULT_COLOR,
-
-				// Senior trees
-				[
-					">=",
-					["get", "age"],
-					[
-						"case",
-						["==", ["get", "district"], "Mitte"],
-						13,
-						["==", ["get", "district"], "Pankow"],
-						12,
-						["==", ["get", "district"], "Neukölln"],
-						10,
-						["==", ["get", "district"], "Lichtenberg"],
-						13,
-						5,
-					],
-				],
-				TREE_DEFAULT_COLOR,
-
-				// Junior trees - skipped, not applicable for "special" districts
-				//...
-
-				// Baby trees
-				[">=", ["get", "age"], 0],
-				TREE_DEFAULT_COLOR,
-
-				// Fallback
-				TREE_GRAY_COLOR,
+				"in",
+				["get", "district"],
+				["literal", ["Mitte", "Pankow", "Neukölln", "Lichtenberg"]],
 			],
+			TREE_DEFAULT_COLOR,
 
 			// Define logic for "normal" districts
 			[

--- a/src/components/map/hooks/use-tree-circle-style.tsx
+++ b/src/components/map/hooks/use-tree-circle-style.tsx
@@ -89,61 +89,92 @@ export function useTreeCircleStyle() {
 	}): Expression => {
 		const defaultExpression: Expression = [
 			"case",
-			["==", ["get", "age"], ""],
-			TREE_DEFAULT_COLOR,
-			[
-				">",
-				["get", "age"],
-				// TODO: by district here
-				[
-					"case",
-					["==", ["get", "district"], "Neukölln"],
-					10,
-					["==", ["get", "district"], "Pankow"],
-					12,
-					5,
-				],
-			],
-			TREE_DEFAULT_COLOR, // Color for trees older than 10 years
-			[
-				">=",
-				["get", "age"],
-				[
-					"case",
-					["==", ["get", "district"], "Neukölln"],
-					10,
-					["==", ["get", "district"], "Pankow"],
-					12,
-					5,
-				],
-			],
+			["in", ["get", "district"], "Mitte", "Pankow", "Neukölln", "Lichtenberg"],
+
+			// Define logic for "special" districts
 			[
 				"case",
+
+				// Fall back to default color for trees with undefined age
+				["==", ["get", "age"], ""],
+				TREE_DEFAULT_COLOR,
+
+				// Senior trees
 				[
 					">=",
+					["get", "age"],
 					[
-						"+",
-						["round", ["get", "total_water_sum_liters"]],
-						["coalesce", ["feature-state", "todays_waterings"], 0],
+						"case",
+						["==", ["get", "district"], "Mitte"],
+						13,
+						["==", ["get", "district"], "Pankow"],
+						12,
+						["==", ["get", "district"], "Neukölln"],
+						10,
+						["==", ["get", "district"], "Lichtenberg"],
+						13,
+						5,
 					],
-					200,
 				],
 				TREE_DEFAULT_COLOR,
-				[
-					">=",
-					[
-						"+",
-						["round", ["get", "total_water_sum_liters"]],
-						["coalesce", ["feature-state", "todays_waterings"], 0],
-					],
-					100,
-				],
-				TREE_YELLOW_COLOR,
-				TREE_ORANGE_COLOR,
+
+				// Junior trees - skipped, not applicable for "special" districts
+				//...
+
+				// Baby trees
+				[">=", ["get", "age"], 0],
+				TREE_DEFAULT_COLOR,
+
+				// Fallback
+				TREE_GRAY_COLOR,
 			],
-			[">=", ["get", "age"], 0],
-			TREE_DEFAULT_COLOR,
-			TREE_GRAY_COLOR,
+
+			// Define logic for "normal" districts
+			[
+				"case",
+
+				// Fall back to default color for trees with undefined age
+				["==", ["get", "age"], ""],
+				TREE_DEFAULT_COLOR,
+
+				// Senior trees
+				[">", ["get", "age"], 10],
+				TREE_DEFAULT_COLOR,
+
+				// Junior trees
+				[">=", ["get", "age"], 5],
+				[
+					"case",
+					[
+						">=",
+						[
+							"+",
+							["round", ["get", "total_water_sum_liters"]],
+							["coalesce", ["feature-state", "todays_waterings"], 0],
+						],
+						200,
+					],
+					TREE_DEFAULT_COLOR,
+					[
+						">=",
+						[
+							"+",
+							["round", ["get", "total_water_sum_liters"]],
+							["coalesce", ["feature-state", "todays_waterings"], 0],
+						],
+						100,
+					],
+					TREE_YELLOW_COLOR,
+					TREE_ORANGE_COLOR,
+				],
+
+				// Baby trees
+				[">=", ["get", "age"], 0],
+				TREE_DEFAULT_COLOR,
+
+				// Fallback
+				TREE_GRAY_COLOR,
+			],
 		];
 
 		if (!isSomeFilterActive) {

--- a/src/components/tree-detail/hooks/use-tree-age-classification.tsx
+++ b/src/components/tree-detail/hooks/use-tree-age-classification.tsx
@@ -8,20 +8,49 @@ export function useTreeAgeClassification(
 	treeData?: TreeCoreData,
 	referenceDate?: Date,
 ): TreeAgeClassificationState {
-	console.log(treeData);
+	const specialDistrictsBabyAgeLimit = {
+		Mitte: 12,
+		Pankow: 11,
+		Neukölln: 9,
+		Lichtenberg: 12,
+	};
 
-	const BABY_AGE_LIMIT = 4;
+	const isSpecialDistrict = (district: string) => {
+		return Object.keys(specialDistrictsBabyAgeLimit).includes(district);
+	};
+
+	const babyAgeLimit = (district: string) => {
+		if (isSpecialDistrict(district)) {
+			return specialDistrictsBabyAgeLimit[
+				district as keyof typeof specialDistrictsBabyAgeLimit
+			];
+		}
+		return 4;
+	};
+
 	const JUNIOR_TREES_AGE_LIMIT = 10;
 
 	const treeAgeClassification = () => {
 		if (!treeData || !treeData.pflanzjahr || treeData.pflanzjahr === 0) {
 			return TreeAgeClassification.UNKNOWN;
 		}
+
 		const age =
 			(referenceDate ?? new Date()).getFullYear() - treeData.pflanzjahr;
-		if (age <= BABY_AGE_LIMIT) {
+
+		// Only baby and senior trees in special districts
+		if (isSpecialDistrict(treeData.bezirk)) {
+			if (age <= babyAgeLimit(treeData.bezirk)) {
+				return TreeAgeClassification.BABY;
+			}
+			return TreeAgeClassification.SENIOR;
+		}
+
+		// Baby, junior and senior trees in normal districts
+		if (age <= babyAgeLimit(treeData.bezirk)) {
 			return TreeAgeClassification.BABY;
 		}
+
 		if (age <= JUNIOR_TREES_AGE_LIMIT) {
 			return TreeAgeClassification.JUNIOR;
 		}

--- a/src/components/tree-detail/hooks/use-tree-age-classification.tsx
+++ b/src/components/tree-detail/hooks/use-tree-age-classification.tsx
@@ -8,6 +8,8 @@ export function useTreeAgeClassification(
 	treeData?: TreeCoreData,
 	referenceDate?: Date,
 ): TreeAgeClassificationState {
+	console.log(treeData);
+
 	const BABY_AGE_LIMIT = 4;
 	const JUNIOR_TREES_AGE_LIMIT = 10;
 

--- a/src/tests/unit/baby-tree-water-needs-special-district.test.ts
+++ b/src/tests/unit/baby-tree-water-needs-special-district.test.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "vitest";
+import { useTreeAgeClassification } from "../../components/tree-detail/hooks/use-tree-age-classification";
+import { useTreeWaterNeedsData } from "../../components/tree-detail/hooks/use-tree-water-needs-data";
+import {
+	TreeAgeClassification,
+	TreeCoreData,
+} from "../../components/tree-detail/tree-types";
+
+test("should calculate correct water needs for baby tree in special district", () => {
+	const treeData: TreeCoreData = {
+		id: "00008100:00150353",
+		lat: "13.39502",
+		lng: "52.53667",
+		art_dtsch: "Pyramiden-Hainbuche",
+		art_bot: "Carpinus betulus 'Fastigiata'",
+		gattung_deutsch: "HAINBUCHE",
+		gattung: "CARPINUS",
+		pflanzjahr: 2012,
+		standalter: "11",
+		baumhoehe: "12",
+		bezirk: "Mitte",
+		eigentuemer: "Land Berlin",
+		radolan_sum: 281,
+		radolan_days: [
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 3, 1, 0, 2, 6, 9, 0, 1, 0, 4,
+			4, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 5, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 12, 2, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 2, 2, 2, 2, 1, 0, 0, 5, 2, 5,
+			8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 2, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 7,
+			7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 10,
+		],
+		geom: {
+			coordinates: [13.39502, 52.53667],
+		},
+		caretaker: null,
+	};
+
+	const { treeAgeClassification, treeAge } = useTreeAgeClassification(
+		treeData,
+		new Date("2024-01-01T00:00+00:00"),
+	);
+	expect(treeAge).toBe(12);
+	expect(treeAgeClassification).toBe(TreeAgeClassification.BABY);
+
+	const {
+		rainSum,
+		rainPercentage,
+		wateringSum,
+		wateringPercentage,
+		otherWateringPercentage,
+		referenceWaterAmount,
+		shouldBeWatered,
+		waterParts,
+	} = useTreeWaterNeedsData(treeData, [], treeAgeClassification);
+
+	expect(rainSum).toBe(15.3);
+	expect(wateringSum).toBe(0);
+	expect(referenceWaterAmount).toBe(100);
+	expect(rainPercentage).toBe(0.153);
+	expect(wateringPercentage).toBe(0);
+	expect(otherWateringPercentage).toBe(0.847);
+	expect(shouldBeWatered).toBe(false);
+	expect(waterParts.map((p) => p.progress)).toEqual([0.153, 0, 0.847]);
+});

--- a/src/tests/unit/senior-tree-water-needs-special-district.test.ts
+++ b/src/tests/unit/senior-tree-water-needs-special-district.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "vitest";
+import { useTreeAgeClassification } from "../../components/tree-detail/hooks/use-tree-age-classification";
+import { useTreeWaterNeedsData } from "../../components/tree-detail/hooks/use-tree-water-needs-data";
+import {
+	TreeAgeClassification,
+	TreeCoreData,
+} from "../../components/tree-detail/tree-types";
+
+test("should calculate correct water needs for senior tree in special district", () => {
+	const treeData: TreeCoreData = {
+		id: "00008100:0014f6e0",
+		lat: "13.40601",
+		lng: "52.53168",
+		art_dtsch: "Saulen-Hainbuche 'Frans Fontaine'",
+		art_bot: "Carpinus betulus 'Frans Fontaine'",
+		gattung_deutsch: "HAINBUCHE",
+		gattung: "CARPINUS",
+		pflanzjahr: 2011,
+		standalter: "12",
+		baumhoehe: "16",
+		bezirk: "Mitte",
+		eigentuemer: "Land Berlin",
+		radolan_sum: 281,
+		radolan_days: [
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 3, 1, 0, 2, 6, 9, 0, 1, 0, 4,
+			4, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 5, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 12, 2, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 2, 2, 2, 2, 1, 0, 0, 5, 2, 5,
+			8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 2, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 7,
+			7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4, 5, 10,
+		],
+		geom: {
+			coordinates: [13.40601, 52.53168],
+		},
+		caretaker: null,
+	};
+
+	const { treeAgeClassification, treeAge } = useTreeAgeClassification(
+		treeData,
+		new Date("2024-01-01T00:00+00:00"),
+	);
+	expect(treeAge).toBe(13);
+	expect(treeAgeClassification).toBe(TreeAgeClassification.SENIOR);
+
+	const {
+		rainSum,
+		rainPercentage,
+		wateringSum,
+		wateringPercentage,
+		otherWateringPercentage,
+		referenceWaterAmount,
+		shouldBeWatered,
+		waterParts,
+	} = useTreeWaterNeedsData(treeData, [], treeAgeClassification);
+
+	expect(rainSum).toBe(15.3);
+	expect(wateringSum).toBe(0);
+	expect(referenceWaterAmount).toBe(300);
+	expect(rainPercentage).toBe(0.051000000000000004);
+	expect(wateringPercentage).toBe(0);
+	expect(otherWateringPercentage).toBe(0.949);
+	expect(shouldBeWatered).toBe(false);
+	expect(waterParts.map((p) => p.progress)).toEqual([
+		0.051000000000000004, 0, 0.949,
+	]);
+});


### PR DESCRIPTION
https://app.asana.com/0/1204152181784036/1208351541946150

needs https://github.com/technologiestiftung/giessdenkiez-de-dwd-harvester/pull/135

For testing, use these tree ids:

Mitte:
- 00008100:00150353 -> 12 years, covered by district
- 00008100:0014f6e0 -> 13 years, covered by groundwater

Pankow:
- 00008100:0028fbd8 -> 11 years, covered by district
- 00008100:002e51c0 -> 12 years, covered by groundwater

Neukölln:
- 00008100:00288b4f -> 9 years, covered by district
- 00008100:0022e9d6 -> 10 years, covered by groundwater

Lichtenberg:
- 00008100:001ff320 -> 12 years, covered by district
- 00008100:001fe1d2 -> 13 years, covered by groundwater