### PR TITLE
Update README_DEV.md, fix filename

### DIFF
--- a/README_DEV.md
+++ b/README_DEV.md
@@ -29,7 +29,7 @@
   - Change directory to `giessdenkiez-de-postgres-api` repository, make sure you have checked out the `master` branch
   - `nvm install && nvm use`
   - `npm ci`
-  - `cp .env.sample .env`
+  - `cp .env.example .env`
   - Load the `.env` file: `direnv allow`
   - `npx supabase start` which will start a local [Supabase](https://supabase.com/) instance
   - Now the Postgres database (and all other Supabase services) are running locally in Docker containers


### PR DESCRIPTION
The [README_DEV.md](https://github.com/technologiestiftung/giessdenkiez-de/blob/main/README_DEV.md) refers to file .env.sample when the file in the actual repo seems to be .env.example (https://github.com/technologiestiftung/giessdenkiez-de-postgres-api/blob/master/.env.example)

