### PR TITLE
chore: Update to latest harvester version v2.9.2

### DIFF
--- a/.github/workflows/rain.yml
+++ b/.github/workflows/rain.yml
@@ -19,7 +19,7 @@ jobs:
     name: Aggregate rain data from DWD radolan
     steps:
       - name: Harvester
-        uses: docker://technologiestiftung/giessdenkiez-de-dwd-harvester:v2.9.0
+        uses: docker://technologiestiftung/giessdenkiez-de-dwd-harvester:v2.9.2
         id: harvester
         env:
           PG_SERVER: ${{ secrets.PG_SERVER }}


### PR DESCRIPTION
Makes this workflow ready for 2025 and should fix all existing issues.