### PR TITLE
fix: replace hardcoded strings with i18n keys and improve switch button accessibility

### DIFF
--- a/src/components/buttons/switch-button.tsx
+++ b/src/components/buttons/switch-button.tsx
@@ -4,15 +4,22 @@ type SwitchButtonProps = {
 	isEnabled: boolean;
 	onToggle: () => void;
 	isDisabled?: boolean;
+	ariaLabel: string;
 };
 
 export const SwitchButton: React.FC<SwitchButtonProps> = ({
 	isEnabled,
 	onToggle,
 	isDisabled = false,
+	ariaLabel,
 }) => {
 	return (
 		<button
+			type="button"
+			role="switch"
+			aria-checked={isEnabled}
+			aria-label={ariaLabel}
+			disabled={isDisabled}
 			onClick={() => {
 				onToggle();
 			}}
@@ -20,7 +27,7 @@ export const SwitchButton: React.FC<SwitchButtonProps> = ({
 				isEnabled && !isDisabled
 					? "border-gdk-blue justify-end"
 					: "border-[#989898] justify-start"
-			}`}
+			} ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}`}
 		>
 			<div
 				className={`w-5 h-5 rounded-full ${

--- a/src/components/filter/filter-switch.tsx
+++ b/src/components/filter/filter-switch.tsx
@@ -22,6 +22,7 @@ export const FilterSwitch: React.FC<FilterSwitchProps> = ({
 					onToggle={onToggle}
 					isEnabled={isEnabled}
 					isDisabled={isDisabled}
+					ariaLabel={name}
 				/>
 			</div>
 		</div>

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -15,7 +15,7 @@ export const Navbar: React.FC = () => {
 
 	const navItems = [
 		{ label: i18n.navbar.map, path: "/map", icon: <MapIcon /> },
-		{ label: "Stats", path: "/stats", icon: <BarChartIcon /> },
+		{ label: i18n.navbar.stats, path: "/stats", icon: <BarChartIcon /> },
 		{
 			label: i18n.navbar.profile.sidebarLabel,
 			path: "/profile",

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -1,15 +1,17 @@
 import React from "react";
 import { useAuthStore } from "../../auth/auth-store";
+import { useI18nStore } from "../../i18n/i18n-store";
 import { AuthCard } from "./auth-card/auth-card";
 import { ProfileLoggedIn } from "./profile-logged-in/profile-logged-in";
 import { LanguageToggle } from "../router/languageToggle";
 
 export const Profile: React.FC = () => {
 	const { isLoggedIn } = useAuthStore();
+	const i18n = useI18nStore().i18n();
 
 	switch (isLoggedIn()) {
 		case undefined:
-			return <div className="mx-auto my-auto">Loading...</div>;
+			return <div className="mx-auto my-auto">{i18n.loading.profileLoading}</div>;
 
 		case false:
 			return (

--- a/src/components/tree-detail/last-waterings/watering-card.tsx
+++ b/src/components/tree-detail/last-waterings/watering-card.tsx
@@ -29,6 +29,7 @@ function getDisplayedUsername(wateringData: TreeWateringData) {
 }
 
 export const WateringCard: React.FC<WateringCardProps> = ({ wateringData }) => {
+	const i18n = useI18nStore().i18n();
 	const formatDate = useI18nStore().formatDate;
 	const { username } = useProfileStore();
 	const { deleteWatering } = useWaterTree();
@@ -180,7 +181,7 @@ export const WateringCard: React.FC<WateringCardProps> = ({ wateringData }) => {
 						}`}
 					>
 						<PrimaryDestructiveButton
-							label={"Löschen"}
+							label={i18n.treeDetail.lastWaterings.delete}
 							onClick={onClickDelete}
 							isLoading={isDeleteWateringLoading}
 							disabled={isDeleteWateringLoading}

--- a/src/i18n/content-types.ts
+++ b/src/i18n/content-types.ts
@@ -33,6 +33,7 @@ interface Legend {
 
 interface Navbar {
 	map: string;
+	stats: string;
 	profile: {
 		sidebarLabel: string;
 		title: string;
@@ -221,6 +222,7 @@ interface LastWaterings {
 	nothingLast30Days: string;
 	before: string;
 	nothingBefore: string;
+	delete: string;
 }
 
 interface TreeDetail {
@@ -297,6 +299,7 @@ interface Splash {
 interface Loading {
 	mapLoading: string;
 	treeLoading: string;
+	profileLoading: string;
 }
 
 interface Contact {

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -41,6 +41,7 @@ export const de: Content = {
 	},
 	navbar: {
 		map: "Karte",
+		stats: "Statistiken",
 		profile: {
 			sidebarLabel: "Profil",
 			title: "Dein Profil",
@@ -379,6 +380,7 @@ Der Bezirk ${district} hat uns zusätzliche Informationen zur individuellen Gie�
 			nothingLast30Days: "Keine Gießungen in den letzten 30 Tagen",
 			before: "Vorherige",
 			nothingBefore: "Keine vorherigen Gießungen",
+			delete: "Löschen",
 		},
 		problem: {
 			title: "Problem melden",
@@ -553,6 +555,7 @@ Der Bezirk ${district} hat uns zusätzliche Informationen zur individuellen Gie�
 	loading: {
 		mapLoading: "Wir laden gerade 967.365 Bäume aus dem Berliner Baumbestand.",
 		treeLoading: "Lade Bauminformationen...",
+		profileLoading: "Laden...",
 	},
 	stats: {
 		title: "Statistiken Berlin",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -41,6 +41,7 @@ export const en: Content = {
 	},
 	navbar: {
 		map: "Map",
+		stats: "Stats",
 		profile: {
 			sidebarLabel: "Profile",
 			title: "Your profile",
@@ -369,6 +370,7 @@ The district ${district} has provided us with additional information on the indi
 			nothingLast30Days: "No waterings in the last 30 days",
 			before: "Previous",
 			nothingBefore: "No previous waterings",
+			delete: "Delete",
 		},
 		problem: {
 			title: "Report a problem",
@@ -543,6 +545,7 @@ The district ${district} has provided us with additional information on the indi
 		mapLoading:
 			"We are currently loading 967,365 trees from the Berlin tree population.",
 		treeLoading: "Loading tree information...",
+		profileLoading: "Loading...",
 	},
 	stats: {
 		title: "Berlin Statistics",


### PR DESCRIPTION
Hey! 👋

I was exploring the codebase and noticed a few hardcoded strings that were bypassing the i18n system, plus some missing accessibility attributes on the switch button. Figured I'd fix both since they're small changes.

**i18n fixes:**
- "Stats" in navbar, "Loading..." in profile, "Löschen" in watering card — all moved to proper i18n keys with DE/EN translations

**Accessibility:**
- Added `role="switch"`, `aria-checked` and `aria-label` to the SwitchButton component
- Also wired up the `disabled` attribute properly (was only visual before)

Everything passes `tsc` and `lint`. Let me know if anything needs adjusting!