### PR TITLE
fix: update pump status url to mapcomplete

### DIFF
--- a/src/components/map/hooks/use-map-constants.tsx
+++ b/src/components/map/hooks/use-map-constants.tsx
@@ -53,7 +53,7 @@ export function useMapConstants() {
 
 	// The link is stored in source code instead of environment variable, because of the required string interpolation of lat/lng/id which would be too complicated to handle in environment variables
 	const pumpUpdateLink = (id: number, lat: number, lng: number) => {
-		return `https://mapcomplete.org/theme.html?z=15.1&lat=${lat}&lon=${lng}&userlayout=https%3A%2F%2Fstudio.mapcomplete.org%2F11881%2Fthemes%2Fberlin_emergency_water_pumps%2Fberlin_emergency_water_pumps.json#node/${id}`;
+		return `https://mapcomplete.org/drinking_water?z=15.1&lat=${lat}&lon=${lng}#node/${id}`;
 	};
 
 	return {

--- a/tests/unit/use-map-constants.test.ts
+++ b/tests/unit/use-map-constants.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "vitest";
+import { useMapConstants } from "../../src/components/map/hooks/use-map-constants";
+
+test("pumpUpdateLink generates correct MapComplete drinking water URL", () => {
+  const { pumpUpdateLink } = useMapConstants();
+  
+  const id = 11053702410;
+  const lat = 52.4727;
+  const lng = 13.4459;
+
+  const expectedUrl = "https://mapcomplete.org/drinking_water?z=15.1&lat=52.4727&lon=13.4459#node/11053702410";
+  
+  expect(pumpUpdateLink(id, lat, lng)).toBe(expectedUrl);
+});


### PR DESCRIPTION
## Summary
This PR fixes the broken link for updating pump status in the pump tooltip. The deprecated URL structure was causing a 404 error when users attempted to edit pump details on MapComplete.

## Changes
- Updated `pumpUpdateLink` in `src/components/map/hooks/use-map-constants.tsx` to use the standard MapComplete drinking water theme URL format (`https://mapcomplete.org/drinking_water?...#node/{id}`).

## Testing
- Verified that clicking the "Status in OpenStreetMap aktualisieren" link opens the correct MapComplete page centered on the selected pump node without throwing a 404 error.